### PR TITLE
Rename AWS kms vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ See [config.py](https://github.com/julien777z/pydantic-encryption/blob/main/pyda
 ENCRYPTION_METHOD=aws
 AWS_KMS_KEY_ARN=123
 AWS_KMS_REGION=us-east-1
-AWS_ACCESS_KEY_ID=123
-AWS_SECRET_ACCESS_KEY=123
+AWS_KMS_ACCESS_KEY_ID=123
+AWS_KMS_SECRET_ACCESS_KEY=123
 ```
 
 ```python
@@ -147,8 +147,8 @@ ENCRYPTION_METHOD=aws
 AWS_KMS_ENCRYPT_KEY_ARN=arn:aws:kms:us-east-1:123456789:key/encrypt-key-id
 AWS_KMS_DECRYPT_KEY_ARN=arn:aws:kms:us-east-1:123456789:key/decrypt-key-id
 AWS_KMS_REGION=us-east-1
-AWS_ACCESS_KEY_ID=123
-AWS_SECRET_ACCESS_KEY=123
+AWS_KMS_ACCESS_KEY_ID=123
+AWS_KMS_SECRET_ACCESS_KEY=123
 ```
 
 For read-only scenarios where you only need to decrypt data, you can specify just the decrypt key:
@@ -158,8 +158,8 @@ For read-only scenarios where you only need to decrypt data, you can specify jus
 ENCRYPTION_METHOD=aws
 AWS_KMS_DECRYPT_KEY_ARN=arn:aws:kms:us-east-1:123456789:key/decrypt-key-id
 AWS_KMS_REGION=us-east-1
-AWS_ACCESS_KEY_ID=123
-AWS_SECRET_ACCESS_KEY=123
+AWS_KMS_ACCESS_KEY_ID=123
+AWS_KMS_SECRET_ACCESS_KEY=123
 ```
 
 **Note:** You cannot mix `AWS_KMS_KEY_ARN` with the separate key settings. Use either the global key or the separate encrypt/decrypt keys. If you specify `AWS_KMS_ENCRYPT_KEY_ARN`, you must also specify `AWS_KMS_DECRYPT_KEY_ARN`.

--- a/pydantic_encryption/adapters/encryption/aws.py
+++ b/pydantic_encryption/adapters/encryption/aws.py
@@ -51,20 +51,20 @@ class AWSAdapter(EncryptionAdapter):
             if not (
                 has_key
                 and settings.AWS_KMS_REGION
-                and settings.AWS_ACCESS_KEY_ID
-                and settings.AWS_SECRET_ACCESS_KEY
+                and settings.AWS_KMS_ACCESS_KEY_ID
+                and settings.AWS_KMS_SECRET_ACCESS_KEY
             ):
                 raise ValueError(
-                    "AWS KMS requires AWS_KMS_REGION, AWS_ACCESS_KEY_ID, "
-                    "AWS_SECRET_ACCESS_KEY, and at least one key ARN "
+                    "AWS KMS requires AWS_KMS_REGION, AWS_KMS_ACCESS_KEY_ID, "
+                    "AWS_KMS_SECRET_ACCESS_KEY, and at least one key ARN "
                     "(AWS_KMS_KEY_ARN, AWS_KMS_ENCRYPT_KEY_ARN, or AWS_KMS_DECRYPT_KEY_ARN) to be set."
                 )
 
             cls._kms_client = boto3.client(
                 "kms",
                 region_name=settings.AWS_KMS_REGION,
-                aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
-                aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
+                aws_access_key_id=settings.AWS_KMS_ACCESS_KEY_ID,
+                aws_secret_access_key=settings.AWS_KMS_SECRET_ACCESS_KEY,
             )
 
         if cls._encryption_client is None:

--- a/pydantic_encryption/config.py
+++ b/pydantic_encryption/config.py
@@ -17,8 +17,8 @@ class Settings(BaseSettings):
     AWS_KMS_ENCRYPT_KEY_ARN: Optional[str] = None
     AWS_KMS_DECRYPT_KEY_ARN: Optional[str] = None
     AWS_KMS_REGION: Optional[str] = None
-    AWS_ACCESS_KEY_ID: Optional[str] = None
-    AWS_SECRET_ACCESS_KEY: Optional[str] = None
+    AWS_KMS_ACCESS_KEY_ID: Optional[str] = None
+    AWS_KMS_SECRET_ACCESS_KEY: Optional[str] = None
 
     # Evervault settings
     EVERVAULT_API_KEY: Optional[str] = None


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Renames AWS KMS credential env vars and aligns code/docs accordingly.
> 
> - Updates `Settings` to use `AWS_KMS_ACCESS_KEY_ID` and `AWS_KMS_SECRET_ACCESS_KEY` instead of `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`
> - Adjusts `aws.py` KMS client initialization and validation messages to reference the new env vars
> - Revises README examples (single key and separate encrypt/decrypt keys) to reflect the new `AWS_KMS_*` credential names
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c810787995c4d146e74d59429e76be8a42c2a10d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->