### PR TITLE
Support additional types

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,18 +114,31 @@ print(user.password) # hashed
 |------|---------|
 | `str` | `"hello@example.com"` |
 | `bytes` | `b"binary data"` |
+| `bool` | `True`, `False` |
 | `int` | `42` |
+| `float` | `3.14159` |
+| `Decimal` | `Decimal("99999.99")` |
+| `UUID` | `UUID("12345678-1234-5678-1234-567812345678")` |
 | `date` | `date(1990, 5, 15)` |
 | `datetime` | `datetime(2025, 1, 21, 14, 30, 45)` |
+| `time` | `time(14, 30, 45)` |
+| `timedelta` | `timedelta(hours=2, minutes=30)` |
 
 ```python
-from datetime import date, datetime
+import uuid
+from datetime import date, datetime, time, timedelta
+from decimal import Decimal
 
 class User(Base, table=True):
     email: str = Field(sa_type=SQLAlchemyEncrypted())
     birth_date: date = Field(sa_type=SQLAlchemyEncrypted())
     last_login: datetime = Field(sa_type=SQLAlchemyEncrypted())
     age: int = Field(sa_type=SQLAlchemyEncrypted())
+    balance: float = Field(sa_type=SQLAlchemyEncrypted())
+    salary: Decimal = Field(sa_type=SQLAlchemyEncrypted())
+    external_id: uuid.UUID = Field(sa_type=SQLAlchemyEncrypted())
+    login_time: time = Field(sa_type=SQLAlchemyEncrypted())
+    session_duration: timedelta = Field(sa_type=SQLAlchemyEncrypted())
 ```
 
 ## Choose an Encryption Method

--- a/README.md
+++ b/README.md
@@ -106,6 +106,28 @@ print(user.email) # decrypted
 print(user.password) # hashed
 ```
 
+### Supported Types
+
+`SQLAlchemyEncrypted` automatically detects and preserves the Python type of your data:
+
+| Type | Example |
+|------|---------|
+| `str` | `"hello@example.com"` |
+| `bytes` | `b"binary data"` |
+| `int` | `42` |
+| `date` | `date(1990, 5, 15)` |
+| `datetime` | `datetime(2025, 1, 21, 14, 30, 45)` |
+
+```python
+from datetime import date, datetime
+
+class User(Base, table=True):
+    email: str = Field(sa_type=SQLAlchemyEncrypted())
+    birth_date: date = Field(sa_type=SQLAlchemyEncrypted())
+    last_login: datetime = Field(sa_type=SQLAlchemyEncrypted())
+    age: int = Field(sa_type=SQLAlchemyEncrypted())
+```
+
 ## Choose an Encryption Method
 
 You can choose which encryption algorithm to use by setting the `ENCRYPTION_METHOD` environment variable.

--- a/pydantic_encryption/integrations/sqlalchemy.py
+++ b/pydantic_encryption/integrations/sqlalchemy.py
@@ -18,6 +18,7 @@ class _TypePrefix(StrEnum):
 
     STR = "str"
     BYTES = "bytes"
+    BOOL = "bool"
     INT = "int"
     DATE = "date"
     DATETIME = "datetime"
@@ -29,7 +30,7 @@ class SQLAlchemyEncrypted(TypeDecorator):
     impl = LargeBinary
     cache_ok = True
 
-    def _serialize_value(self, value: str | bytes | int | date | datetime) -> str:
+    def _serialize_value(self, value: str | bytes | bool | int | date | datetime) -> str:
         """Serialize a value with type prefix for encryption."""
         match value:
             case datetime():
@@ -38,12 +39,14 @@ class SQLAlchemyEncrypted(TypeDecorator):
                 return f"{_TypePrefix.DATE}:{value.isoformat()}"
             case bytes():
                 return f"{_TypePrefix.BYTES}:{base64.b64encode(value).decode('ascii')}"
+            case bool():
+                return f"{_TypePrefix.BOOL}:{value}"
             case int():
                 return f"{_TypePrefix.INT}:{value}"
             case _:
                 return f"{_TypePrefix.STR}:{value}"
 
-    def _deserialize_value(self, value: str) -> str | bytes | int | date | datetime:
+    def _deserialize_value(self, value: str) -> str | bytes | bool | int | date | datetime:
         """Deserialize a decrypted value based on its type prefix."""
         prefix, _, data = value.partition(":")
         match prefix:
@@ -53,6 +56,8 @@ class SQLAlchemyEncrypted(TypeDecorator):
                 return date.fromisoformat(data)
             case _TypePrefix.BYTES:
                 return base64.b64decode(data)
+            case _TypePrefix.BOOL:
+                return data == "True"
             case _TypePrefix.INT:
                 return int(data)
             case _TypePrefix.STR:
@@ -60,7 +65,7 @@ class SQLAlchemyEncrypted(TypeDecorator):
             case _:
                 return value
 
-    def _process_encrypt_value(self, value: str | bytes | int | date | datetime | None) -> EncryptedValue | None:
+    def _process_encrypt_value(self, value: str | bytes | bool | int | date | datetime | None) -> EncryptedValue | None:
         if value is None:
             return None
 
@@ -91,14 +96,14 @@ class SQLAlchemyEncrypted(TypeDecorator):
                 raise ValueError(f"Unknown encryption method: {settings.ENCRYPTION_METHOD}")
 
     def process_bind_param(
-        self, value: str | bytes | int | date | datetime | None, dialect
+        self, value: str | bytes | bool | int | date | datetime | None, dialect
     ) -> bytes | None:
         """Encrypts data before binding it to the database."""
 
         return self._process_encrypt_value(value)
 
     def process_literal_param(
-        self, value: str | bytes | int | date | datetime | None, dialect
+        self, value: str | bytes | bool | int | date | datetime | None, dialect
     ) -> bytes | None:
         """Encrypts data for literal SQL expressions."""
 
@@ -106,7 +111,7 @@ class SQLAlchemyEncrypted(TypeDecorator):
 
     def process_result_value(
         self, value: str | bytes | None, dialect
-    ) -> str | bytes | int | date | datetime | None:
+    ) -> str | bytes | bool | int | date | datetime | None:
         """Decrypts data after retrieving it from the database."""
 
         if value is None:

--- a/pydantic_encryption/integrations/sqlalchemy.py
+++ b/pydantic_encryption/integrations/sqlalchemy.py
@@ -1,3 +1,7 @@
+import base64
+from datetime import date, datetime
+from enum import StrEnum
+
 from pydantic_encryption._lazy import require_optional_dependency
 
 require_optional_dependency("sqlalchemy", "sqlalchemy")
@@ -6,26 +10,69 @@ from sqlalchemy.types import LargeBinary, TypeDecorator
 
 from pydantic_encryption.adapters import encryption, hashing
 from pydantic_encryption.config import settings
-from pydantic_encryption.types import DecryptedValue, EncryptedValue, EncryptionMethod, HashedValue
+from pydantic_encryption.types import EncryptedValue, EncryptionMethod, HashedValue
+
+
+class _TypePrefix(StrEnum):
+    """Type prefixes for auto-detection of encrypted field types."""
+
+    STR = "str"
+    BYTES = "bytes"
+    INT = "int"
+    DATE = "date"
+    DATETIME = "datetime"
 
 
 class SQLAlchemyEncrypted(TypeDecorator):
-    """Type adapter for SQLAlchemy to encrypt and decrypt strings using the specified encryption method."""
+    """Type adapter for SQLAlchemy to encrypt and decrypt data using the specified encryption method."""
 
     impl = LargeBinary
     cache_ok = True
 
-    def _process_encrypt_value(self, value: str | bytes | None) -> EncryptedValue | None:
+    def _serialize_value(self, value: str | bytes | int | date | datetime) -> str:
+        """Serialize a value with type prefix for encryption."""
+        match value:
+            case datetime():
+                return f"{_TypePrefix.DATETIME}:{value.isoformat()}"
+            case date():
+                return f"{_TypePrefix.DATE}:{value.isoformat()}"
+            case bytes():
+                return f"{_TypePrefix.BYTES}:{base64.b64encode(value).decode('ascii')}"
+            case int():
+                return f"{_TypePrefix.INT}:{value}"
+            case _:
+                return f"{_TypePrefix.STR}:{value}"
+
+    def _deserialize_value(self, value: str) -> str | bytes | int | date | datetime:
+        """Deserialize a decrypted value based on its type prefix."""
+        prefix, _, data = value.partition(":")
+        match prefix:
+            case _TypePrefix.DATETIME:
+                return datetime.fromisoformat(data)
+            case _TypePrefix.DATE:
+                return date.fromisoformat(data)
+            case _TypePrefix.BYTES:
+                return base64.b64decode(data)
+            case _TypePrefix.INT:
+                return int(data)
+            case _TypePrefix.STR:
+                return data
+            case _:
+                return value
+
+    def _process_encrypt_value(self, value: str | bytes | int | date | datetime | None) -> EncryptedValue | None:
         if value is None:
             return None
 
+        serialized_value = self._serialize_value(value)
+
         match settings.ENCRYPTION_METHOD:
             case EncryptionMethod.FERNET:
-                return encryption.fernet.FernetAdapter.encrypt(value)
+                return encryption.fernet.FernetAdapter.encrypt(serialized_value)
             case EncryptionMethod.EVERVAULT:
-                return encryption.evervault.EvervaultAdapter.encrypt(value)
+                return encryption.evervault.EvervaultAdapter.encrypt(serialized_value)
             case EncryptionMethod.AWS:
-                return encryption.aws.AWSAdapter.encrypt(value)
+                return encryption.aws.AWSAdapter.encrypt(serialized_value)
             case _:
                 raise ValueError(f"Unknown encryption method: {settings.ENCRYPTION_METHOD}")
 
@@ -43,29 +90,35 @@ class SQLAlchemyEncrypted(TypeDecorator):
             case _:
                 raise ValueError(f"Unknown encryption method: {settings.ENCRYPTION_METHOD}")
 
-    def process_bind_param(self, value: str | bytes | None, dialect) -> str | bytes | None:
-        """Encrypts a string before binding it to the database."""
+    def process_bind_param(
+        self, value: str | bytes | int | date | datetime | None, dialect
+    ) -> bytes | None:
+        """Encrypts data before binding it to the database."""
 
         return self._process_encrypt_value(value)
 
-    def process_literal_param(self, value: str | bytes | None, dialect) -> str | bytes | None:
-        """Encrypts a string for literal SQL expressions."""
+    def process_literal_param(
+        self, value: str | bytes | int | date | datetime | None, dialect
+    ) -> bytes | None:
+        """Encrypts data for literal SQL expressions."""
 
         return self._process_encrypt_value(value)
 
-    def process_result_value(self, value: str | bytes | None, dialect) -> DecryptedValue | None:
-        """Decrypts a string after retrieving it from the database."""
+    def process_result_value(
+        self, value: str | bytes | None, dialect
+    ) -> str | bytes | int | date | datetime | None:
+        """Decrypts data after retrieving it from the database."""
 
         if value is None:
             return None
 
         decrypted_value = self._process_decrypt_value(value)
 
-        return DecryptedValue(decrypted_value)
+        return self._deserialize_value(decrypted_value)
 
     @property
     def python_type(self):
-        """Return the Python type this is bound to (str)."""
+        """Return the Python type this is bound to."""
 
         return self.impl.python_type
 

--- a/pydantic_encryption/integrations/sqlalchemy.py
+++ b/pydantic_encryption/integrations/sqlalchemy.py
@@ -99,11 +99,7 @@ class SQLAlchemyEncrypted(TypeDecorator):
                 return time.fromisoformat(data)
             case _TypePrefix.TIMEDELTA:
                 parts = data.split(",")
-                if len(parts) == 3:
-                    # New format: days,seconds,microseconds
-                    return timedelta(days=int(parts[0]), seconds=int(parts[1]), microseconds=int(parts[2]))
-                # Legacy format: total_seconds as float
-                return timedelta(seconds=float(data))
+                return timedelta(days=int(parts[0]), seconds=int(parts[1]), microseconds=int(parts[2]))
             case _TypePrefix.BYTES:
                 return base64.b64decode(data)
             case _TypePrefix.BOOL:

--- a/pydantic_encryption/integrations/sqlalchemy.py
+++ b/pydantic_encryption/integrations/sqlalchemy.py
@@ -1,6 +1,9 @@
 import base64
-from datetime import date, datetime
+from datetime import date, datetime, time, timedelta
+from decimal import Decimal
 from enum import StrEnum
+from typing import Final
+from uuid import UUID
 
 from pydantic_encryption._lazy import require_optional_dependency
 
@@ -12,6 +15,11 @@ from pydantic_encryption.adapters import encryption, hashing
 from pydantic_encryption.config import settings
 from pydantic_encryption.types import EncryptedValue, EncryptionMethod, HashedValue
 
+# Type alias for all supported encrypted value types
+EncryptableValue = str | bytes | bool | int | float | Decimal | UUID | date | datetime | time | timedelta
+
+_VERSION_PREFIX: Final[str] = "v1"
+
 
 class _TypePrefix(StrEnum):
     """Type prefixes for auto-detection of encrypted field types."""
@@ -20,8 +28,13 @@ class _TypePrefix(StrEnum):
     BYTES = "bytes"
     BOOL = "bool"
     INT = "int"
+    FLOAT = "float"
+    DECIMAL = "decimal"
+    UUID = "uuid"
     DATE = "date"
     DATETIME = "datetime"
+    TIME = "time"
+    TIMEDELTA = "timedelta"
 
 
 class SQLAlchemyEncrypted(TypeDecorator):
@@ -30,42 +43,80 @@ class SQLAlchemyEncrypted(TypeDecorator):
     impl = LargeBinary
     cache_ok = True
 
-    def _serialize_value(self, value: str | bytes | bool | int | date | datetime) -> str:
-        """Serialize a value with type prefix for encryption."""
+    def _serialize_value(self, value: EncryptableValue) -> str:
+        """Serialize a value with version and type prefix for encryption.
+
+        Format: "v1:type:data"
+        """
         match value:
             case datetime():
-                return f"{_TypePrefix.DATETIME}:{value.isoformat()}"
+                type_data = f"{_TypePrefix.DATETIME}:{value.isoformat()}"
             case date():
-                return f"{_TypePrefix.DATE}:{value.isoformat()}"
+                type_data = f"{_TypePrefix.DATE}:{value.isoformat()}"
+            case time():
+                type_data = f"{_TypePrefix.TIME}:{value.isoformat()}"
+            case timedelta():
+                type_data = f"{_TypePrefix.TIMEDELTA}:{value.total_seconds()}"
             case bytes():
-                return f"{_TypePrefix.BYTES}:{base64.b64encode(value).decode('ascii')}"
+                type_data = f"{_TypePrefix.BYTES}:{base64.b64encode(value).decode('ascii')}"
             case bool():
-                return f"{_TypePrefix.BOOL}:{value}"
+                type_data = f"{_TypePrefix.BOOL}:{str(value).lower()}"
             case int():
-                return f"{_TypePrefix.INT}:{value}"
+                type_data = f"{_TypePrefix.INT}:{value}"
+            case float():
+                type_data = f"{_TypePrefix.FLOAT}:{value!r}"
+            case Decimal():
+                type_data = f"{_TypePrefix.DECIMAL}:{value}"
+            case UUID():
+                type_data = f"{_TypePrefix.UUID}:{value}"
             case _:
-                return f"{_TypePrefix.STR}:{value}"
+                type_data = f"{_TypePrefix.STR}:{value}"
 
-    def _deserialize_value(self, value: str) -> str | bytes | bool | int | date | datetime:
-        """Deserialize a decrypted value based on its type prefix."""
-        prefix, _, data = value.partition(":")
-        match prefix:
+        return f"{_VERSION_PREFIX}:{type_data}"
+
+    def _deserialize_value(self, value: str) -> EncryptableValue:
+        """Deserialize a decrypted value based on its version and type prefix.
+
+        Format: "v1:type:data"
+        If no version marker is present, returns the value as a string (legacy format).
+        """
+        version, _, remainder = value.partition(":")
+
+        if not version:
+            return value
+
+        if version != _VERSION_PREFIX:
+            raise RuntimeError("Unknown version")
+
+        type_prefix, _, data = remainder.partition(":")
+
+        match type_prefix:
             case _TypePrefix.DATETIME:
                 return datetime.fromisoformat(data)
             case _TypePrefix.DATE:
                 return date.fromisoformat(data)
+            case _TypePrefix.TIME:
+                return time.fromisoformat(data)
+            case _TypePrefix.TIMEDELTA:
+                return timedelta(seconds=float(data))
             case _TypePrefix.BYTES:
                 return base64.b64decode(data)
             case _TypePrefix.BOOL:
-                return data == "True"
+                return data == "true"
             case _TypePrefix.INT:
                 return int(data)
+            case _TypePrefix.FLOAT:
+                return float(data)
+            case _TypePrefix.DECIMAL:
+                return Decimal(data)
+            case _TypePrefix.UUID:
+                return UUID(data)
             case _TypePrefix.STR:
                 return data
             case _:
                 return value
 
-    def _process_encrypt_value(self, value: str | bytes | bool | int | date | datetime | None) -> EncryptedValue | None:
+    def _process_encrypt_value(self, value: EncryptableValue | None) -> EncryptedValue | None:
         if value is None:
             return None
 
@@ -95,23 +146,17 @@ class SQLAlchemyEncrypted(TypeDecorator):
             case _:
                 raise ValueError(f"Unknown encryption method: {settings.ENCRYPTION_METHOD}")
 
-    def process_bind_param(
-        self, value: str | bytes | bool | int | date | datetime | None, dialect
-    ) -> bytes | None:
+    def process_bind_param(self, value: EncryptableValue | None, dialect) -> bytes | None:
         """Encrypts data before binding it to the database."""
 
         return self._process_encrypt_value(value)
 
-    def process_literal_param(
-        self, value: str | bytes | bool | int | date | datetime | None, dialect
-    ) -> bytes | None:
+    def process_literal_param(self, value: EncryptableValue | None, dialect) -> bytes | None:
         """Encrypts data for literal SQL expressions."""
 
         return self._process_encrypt_value(value)
 
-    def process_result_value(
-        self, value: str | bytes | None, dialect
-    ) -> str | bytes | bool | int | date | datetime | None:
+    def process_result_value(self, value: str | bytes | None, dialect) -> EncryptableValue | None:
         """Decrypts data after retrieving it from the database."""
 
         if value is None:

--- a/pydantic_encryption/integrations/sqlalchemy.py
+++ b/pydantic_encryption/integrations/sqlalchemy.py
@@ -56,7 +56,7 @@ class SQLAlchemyEncrypted(TypeDecorator):
             case time():
                 type_data = f"{_TypePrefix.TIME}:{value.isoformat()}"
             case timedelta():
-                type_data = f"{_TypePrefix.TIMEDELTA}:{value.total_seconds()}"
+                type_data = f"{_TypePrefix.TIMEDELTA}:{value.days},{value.seconds},{value.microseconds}"
             case bytes():
                 type_data = f"{_TypePrefix.BYTES}:{base64.b64encode(value).decode('ascii')}"
             case bool():
@@ -98,6 +98,11 @@ class SQLAlchemyEncrypted(TypeDecorator):
             case _TypePrefix.TIME:
                 return time.fromisoformat(data)
             case _TypePrefix.TIMEDELTA:
+                parts = data.split(",")
+                if len(parts) == 3:
+                    # New format: days,seconds,microseconds
+                    return timedelta(days=int(parts[0]), seconds=int(parts[1]), microseconds=int(parts[2]))
+                # Legacy format: total_seconds as float
                 return timedelta(seconds=float(data))
             case _TypePrefix.BYTES:
                 return base64.b64decode(data)

--- a/pydantic_encryption/integrations/sqlalchemy.py
+++ b/pydantic_encryption/integrations/sqlalchemy.py
@@ -115,7 +115,7 @@ class SQLAlchemyEncrypted(TypeDecorator):
             case _TypePrefix.STR:
                 return data
             case _:
-                return value
+                return data
 
     def _process_encrypt_value(self, value: EncryptableValue | None) -> EncryptedValue | None:
         if value is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic_encryption"
-version = "0.1.3"
+version = "0.2.0"
 description = "Encryption and Hashing Models for Pydantic"
 authors = [
     { name = "Julien Kmec", email = "me@julien.dev" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic_encryption"
-version = "0.2.0"
+version = "0.3.0"
 description = "Encryption and Hashing Models for Pydantic"
 authors = [
     { name = "Julien Kmec", email = "me@julien.dev" },

--- a/tests/integration/database/tables.py
+++ b/tests/integration/database/tables.py
@@ -44,3 +44,7 @@ class User(Base, table=True):
         default=None,
         sa_type=SQLAlchemyEncrypted(),
     )
+    is_active: bool | None = Field(
+        default=None,
+        sa_type=SQLAlchemyEncrypted(),
+    )

--- a/tests/integration/database/tables.py
+++ b/tests/integration/database/tables.py
@@ -1,5 +1,6 @@
 import uuid
-from datetime import date, datetime
+from datetime import date, datetime, time, timedelta
+from decimal import Decimal
 
 from sqlmodel import Field, SQLModel
 
@@ -45,6 +46,26 @@ class User(Base, table=True):
         sa_type=SQLAlchemyEncrypted(),
     )
     is_active: bool | None = Field(
+        default=None,
+        sa_type=SQLAlchemyEncrypted(),
+    )
+    balance: float | None = Field(
+        default=None,
+        sa_type=SQLAlchemyEncrypted(),
+    )
+    salary: Decimal | None = Field(
+        default=None,
+        sa_type=SQLAlchemyEncrypted(),
+    )
+    external_id: uuid.UUID | None = Field(
+        default=None,
+        sa_type=SQLAlchemyEncrypted(),
+    )
+    login_time: time | None = Field(
+        default=None,
+        sa_type=SQLAlchemyEncrypted(),
+    )
+    session_duration: timedelta | None = Field(
         default=None,
         sa_type=SQLAlchemyEncrypted(),
     )

--- a/tests/integration/database/tables.py
+++ b/tests/integration/database/tables.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import date, datetime
 
 from sqlmodel import Field, SQLModel
 
@@ -26,4 +27,16 @@ class User(Base, table=True):
     password: bytes = Field(
         sa_type=SQLAlchemyHashed(),
         nullable=False,
+    )
+    birth_date: date | None = Field(
+        default=None,
+        sa_type=SQLAlchemyEncrypted(),
+    )
+    last_login: datetime | None = Field(
+        default=None,
+        sa_type=SQLAlchemyEncrypted(),
+    )
+    age: int | None = Field(
+        default=None,
+        sa_type=SQLAlchemyEncrypted(),
     )

--- a/tests/integration/database/tables.py
+++ b/tests/integration/database/tables.py
@@ -40,3 +40,7 @@ class User(Base, table=True):
         default=None,
         sa_type=SQLAlchemyEncrypted(),
     )
+    secret_data: bytes | None = Field(
+        default=None,
+        sa_type=SQLAlchemyEncrypted(),
+    )

--- a/tests/integration/test_sqlalchemy.py
+++ b/tests/integration/test_sqlalchemy.py
@@ -25,6 +25,7 @@ class TestIntegrationSQLAlchemy:
         last_login: datetime | None = None,
         age: int | None = None,
         secret_data: bytes | None = None,
+        is_active: bool | None = None,
     ) -> User:
         """Create a user."""
 
@@ -36,6 +37,7 @@ class TestIntegrationSQLAlchemy:
             last_login=last_login,
             age=age,
             secret_data=secret_data,
+            is_active=is_active,
         )
         db_session.add(user)
         db_session.commit()
@@ -118,3 +120,32 @@ class TestIntegrationSQLAlchemy:
 
         assert user.email == TEST_EMAIL
         assert isinstance(user.email, str)
+
+    def test_encrypt_decrypt_bool_true(self, db_session: Session):
+        """Test that boolean True is encrypted and decrypted correctly."""
+
+        user = self._create_user(
+            db_session, username="user9", password=TEST_PASSWORD, is_active=True
+        )
+
+        assert user.is_active is True
+        assert isinstance(user.is_active, bool)
+
+    def test_encrypt_decrypt_bool_false(self, db_session: Session):
+        """Test that boolean False is encrypted and decrypted correctly."""
+
+        user = self._create_user(
+            db_session, username="user10", password=TEST_PASSWORD, is_active=False
+        )
+
+        assert user.is_active is False
+        assert isinstance(user.is_active, bool)
+
+    def test_encrypt_decrypt_bool_none(self, db_session: Session):
+        """Test that boolean None is handled correctly."""
+
+        user = self._create_user(
+            db_session, username="user11", password=TEST_PASSWORD, is_active=None
+        )
+
+        assert user.is_active is None

--- a/tests/integration/test_sqlalchemy.py
+++ b/tests/integration/test_sqlalchemy.py
@@ -10,6 +10,7 @@ TEST_EMAIL: Final[str] = "user1@example.com"
 TEST_BIRTH_DATE: Final[date] = date(1990, 5, 15)
 TEST_LAST_LOGIN: Final[datetime] = datetime(2025, 1, 21, 14, 30, 45)
 TEST_AGE: Final[int] = 34
+TEST_SECRET_DATA: Final[bytes] = b"\x00\x01\x02\x03binary\xff\xfe"
 
 
 class TestIntegrationSQLAlchemy:
@@ -23,6 +24,7 @@ class TestIntegrationSQLAlchemy:
         birth_date: date | None = None,
         last_login: datetime | None = None,
         age: int | None = None,
+        secret_data: bytes | None = None,
     ) -> User:
         """Create a user."""
 
@@ -33,6 +35,7 @@ class TestIntegrationSQLAlchemy:
             birth_date=birth_date,
             last_login=last_login,
             age=age,
+            secret_data=secret_data,
         )
         db_session.add(user)
         db_session.commit()
@@ -97,3 +100,21 @@ class TestIntegrationSQLAlchemy:
 
         assert user.age == TEST_AGE
         assert isinstance(user.age, int)
+
+    def test_encrypt_decrypt_bytes(self, db_session: Session):
+        """Test that bytes fields are encrypted and decrypted correctly."""
+
+        user = self._create_user(
+            db_session, username="user7", password=TEST_PASSWORD, secret_data=TEST_SECRET_DATA
+        )
+
+        assert user.secret_data == TEST_SECRET_DATA
+        assert isinstance(user.secret_data, bytes)
+
+    def test_encrypt_decrypt_str(self, db_session: Session):
+        """Test that string fields are encrypted and decrypted correctly."""
+
+        user = self._create_user(db_session, username="user8", password=TEST_PASSWORD)
+
+        assert user.email == TEST_EMAIL
+        assert isinstance(user.email, str)

--- a/tests/integration/test_sqlalchemy.py
+++ b/tests/integration/test_sqlalchemy.py
@@ -1,11 +1,15 @@
+from datetime import date, datetime, timezone
 from typing import Final
-from sqlalchemy.orm import Session
-from tests.integration.database import User
 
+from sqlalchemy.orm import Session
+
+from tests.integration.database import User
 
 TEST_PASSWORD: Final[str] = "pass123"
 TEST_EMAIL: Final[str] = "user1@example.com"
-TEST_USERNAME: Final[str] = "user1"
+TEST_BIRTH_DATE: Final[date] = date(1990, 5, 15)
+TEST_LAST_LOGIN: Final[datetime] = datetime(2025, 1, 21, 14, 30, 45)
+TEST_AGE: Final[int] = 34
 
 
 class TestIntegrationSQLAlchemy:
@@ -13,38 +17,83 @@ class TestIntegrationSQLAlchemy:
 
     def _create_user(
         self,
-        model: type[User],
         db_session: Session,
+        username: str,
         password: str,
+        birth_date: date | None = None,
+        last_login: datetime | None = None,
+        age: int | None = None,
     ) -> User:
         """Create a user."""
 
-        user = db_session.add(
-            model(
-                username=TEST_USERNAME,
-                email=TEST_EMAIL,
-                password=password,
-            )
+        user = User(
+            username=username,
+            email=TEST_EMAIL,
+            password=password,
+            birth_date=birth_date,
+            last_login=last_login,
+            age=age,
         )
-
+        db_session.add(user)
         db_session.commit()
 
-        return user
+        return db_session.query(User).filter_by(username=username).first()
 
     def test_secure_fields(self, db_session: Session):
         """Test encrypting and hashing fields with the SQLAlchemyEncrypted and SQLAlchemyHashed types."""
 
-        self._create_user(User, db_session, password=TEST_PASSWORD)
+        user = self._create_user(db_session, username="user1", password=TEST_PASSWORD)
 
-        user = db_session.query(User).first()
-
-        self._assert_correct_user(user)
-
-    def _assert_correct_user(self, user: User):
-        """Assert that the user is correct."""
-
-        assert user.username == TEST_USERNAME
+        assert user.username == "user1"
         assert user.email == TEST_EMAIL
+        assert getattr(user.password, "hashed") is True
 
-        assert getattr(user.password, "hashed") is True  # Hashed
-        assert getattr(user.email, "encrypted") is False  # Decrypted
+    def test_encrypt_decrypt_date(self, db_session: Session):
+        """Test that date fields are encrypted and decrypted correctly."""
+
+        user = self._create_user(
+            db_session, username="user2", password=TEST_PASSWORD, birth_date=TEST_BIRTH_DATE
+        )
+
+        assert user.birth_date == TEST_BIRTH_DATE
+        assert isinstance(user.birth_date, date)
+
+    def test_encrypt_decrypt_datetime(self, db_session: Session):
+        """Test that datetime fields are encrypted and decrypted correctly."""
+
+        user = self._create_user(
+            db_session, username="user3", password=TEST_PASSWORD, last_login=TEST_LAST_LOGIN
+        )
+
+        assert user.last_login == TEST_LAST_LOGIN
+        assert isinstance(user.last_login, datetime)
+
+    def test_encrypt_decrypt_datetime_with_timezone(self, db_session: Session):
+        """Test that timezone-aware datetime fields preserve timezone."""
+
+        test_datetime = datetime(2025, 1, 21, 14, 30, 45, tzinfo=timezone.utc)
+
+        user = self._create_user(
+            db_session, username="user4", password=TEST_PASSWORD, last_login=test_datetime
+        )
+
+        assert user.last_login == test_datetime
+        assert user.last_login.tzinfo is not None
+
+    def test_null_date_handling(self, db_session: Session):
+        """Test that None values are handled correctly."""
+
+        user = self._create_user(
+            db_session, username="user5", password=TEST_PASSWORD, birth_date=None, last_login=None
+        )
+
+        assert user.birth_date is None
+        assert user.last_login is None
+
+    def test_encrypt_decrypt_int(self, db_session: Session):
+        """Test that integer fields are encrypted and decrypted correctly."""
+
+        user = self._create_user(db_session, username="user6", password=TEST_PASSWORD, age=TEST_AGE)
+
+        assert user.age == TEST_AGE
+        assert isinstance(user.age, int)

--- a/tests/integration/test_sqlalchemy.py
+++ b/tests/integration/test_sqlalchemy.py
@@ -1,4 +1,6 @@
-from datetime import date, datetime, timezone
+import uuid
+from datetime import date, datetime, time, timedelta, timezone
+from decimal import Decimal
 from typing import Final
 
 from sqlalchemy.orm import Session
@@ -11,6 +13,11 @@ TEST_BIRTH_DATE: Final[date] = date(1990, 5, 15)
 TEST_LAST_LOGIN: Final[datetime] = datetime(2025, 1, 21, 14, 30, 45)
 TEST_AGE: Final[int] = 34
 TEST_SECRET_DATA: Final[bytes] = b"\x00\x01\x02\x03binary\xff\xfe"
+TEST_BALANCE: Final[float] = 1234.56
+TEST_SALARY: Final[Decimal] = Decimal("99999.99")
+TEST_EXTERNAL_ID: Final[uuid.UUID] = uuid.UUID("12345678-1234-5678-1234-567812345678")
+TEST_LOGIN_TIME: Final[time] = time(14, 30, 45)
+TEST_SESSION_DURATION: Final[timedelta] = timedelta(hours=2, minutes=30)
 
 
 class TestIntegrationSQLAlchemy:
@@ -26,6 +33,11 @@ class TestIntegrationSQLAlchemy:
         age: int | None = None,
         secret_data: bytes | None = None,
         is_active: bool | None = None,
+        balance: float | None = None,
+        salary: Decimal | None = None,
+        external_id: uuid.UUID | None = None,
+        login_time: time | None = None,
+        session_duration: timedelta | None = None,
     ) -> User:
         """Create a user."""
 
@@ -38,6 +50,11 @@ class TestIntegrationSQLAlchemy:
             age=age,
             secret_data=secret_data,
             is_active=is_active,
+            balance=balance,
+            salary=salary,
+            external_id=external_id,
+            login_time=login_time,
+            session_duration=session_duration,
         )
         db_session.add(user)
         db_session.commit()
@@ -149,3 +166,96 @@ class TestIntegrationSQLAlchemy:
         )
 
         assert user.is_active is None
+
+    def test_encrypt_decrypt_float(self, db_session: Session):
+        """Test that float fields are encrypted and decrypted correctly."""
+
+        user = self._create_user(
+            db_session, username="user12", password=TEST_PASSWORD, balance=TEST_BALANCE
+        )
+
+        assert user.balance == TEST_BALANCE
+        assert isinstance(user.balance, float)
+
+    def test_encrypt_decrypt_float_negative(self, db_session: Session):
+        """Test that negative float values are handled correctly."""
+
+        user = self._create_user(
+            db_session, username="user13", password=TEST_PASSWORD, balance=-123.45
+        )
+
+        assert user.balance == -123.45
+
+    def test_encrypt_decrypt_decimal(self, db_session: Session):
+        """Test that Decimal fields are encrypted and decrypted correctly."""
+
+        user = self._create_user(
+            db_session, username="user14", password=TEST_PASSWORD, salary=TEST_SALARY
+        )
+
+        assert user.salary == TEST_SALARY
+        assert isinstance(user.salary, Decimal)
+
+    def test_encrypt_decrypt_decimal_high_precision(self, db_session: Session):
+        """Test that high-precision Decimal values are preserved."""
+
+        high_precision = Decimal("123.456789012345678901234567890")
+
+        user = self._create_user(
+            db_session, username="user15", password=TEST_PASSWORD, salary=high_precision
+        )
+
+        assert user.salary == high_precision
+
+    def test_encrypt_decrypt_uuid(self, db_session: Session):
+        """Test that UUID fields are encrypted and decrypted correctly."""
+
+        user = self._create_user(
+            db_session, username="user16", password=TEST_PASSWORD, external_id=TEST_EXTERNAL_ID
+        )
+
+        assert user.external_id == TEST_EXTERNAL_ID
+        assert isinstance(user.external_id, uuid.UUID)
+
+    def test_encrypt_decrypt_time(self, db_session: Session):
+        """Test that time fields are encrypted and decrypted correctly."""
+
+        user = self._create_user(
+            db_session, username="user17", password=TEST_PASSWORD, login_time=TEST_LOGIN_TIME
+        )
+
+        assert user.login_time == TEST_LOGIN_TIME
+        assert isinstance(user.login_time, time)
+
+    def test_encrypt_decrypt_time_with_timezone(self, db_session: Session):
+        """Test that timezone-aware time fields preserve timezone."""
+
+        tz_time = time(14, 30, 45, tzinfo=timezone.utc)
+
+        user = self._create_user(
+            db_session, username="user18", password=TEST_PASSWORD, login_time=tz_time
+        )
+
+        assert user.login_time == tz_time
+        assert user.login_time.tzinfo is not None
+
+    def test_encrypt_decrypt_timedelta(self, db_session: Session):
+        """Test that timedelta fields are encrypted and decrypted correctly."""
+
+        user = self._create_user(
+            db_session, username="user19", password=TEST_PASSWORD, session_duration=TEST_SESSION_DURATION
+        )
+
+        assert user.session_duration == TEST_SESSION_DURATION
+        assert isinstance(user.session_duration, timedelta)
+
+    def test_encrypt_decrypt_timedelta_negative(self, db_session: Session):
+        """Test that negative timedelta values are handled correctly."""
+
+        negative_duration = timedelta(days=-1, hours=-5)
+
+        user = self._create_user(
+            db_session, username="user20", password=TEST_PASSWORD, session_duration=negative_duration
+        )
+
+        assert user.session_duration == negative_duration

--- a/tests/unit/test_sqlalchemy_type.py
+++ b/tests/unit/test_sqlalchemy_type.py
@@ -343,7 +343,8 @@ class TestDeserializeValue:
     def test_deserialize_timedelta(self):
         """Test deserializing a timedelta value."""
 
-        result = self.type_adapter._deserialize_value(f"v1:{_TypePrefix.TIMEDELTA}:95445.0")
+        # timedelta(days=1, hours=2, minutes=30, seconds=45) -> days=1, seconds=9045, microseconds=0
+        result = self.type_adapter._deserialize_value(f"v1:{_TypePrefix.TIMEDELTA}:1,9045,0")
 
         assert result == timedelta(days=1, hours=2, minutes=30, seconds=45)
         assert isinstance(result, timedelta)
@@ -351,14 +352,16 @@ class TestDeserializeValue:
     def test_deserialize_timedelta_negative(self):
         """Test deserializing a negative timedelta."""
 
-        result = self.type_adapter._deserialize_value(f"v1:{_TypePrefix.TIMEDELTA}:-93600.0")
+        # timedelta(days=-1, hours=-2) normalizes to days=-2, seconds=79200, microseconds=0
+        result = self.type_adapter._deserialize_value(f"v1:{_TypePrefix.TIMEDELTA}:-2,79200,0")
 
         assert result == timedelta(days=-1, hours=-2)
 
     def test_deserialize_timedelta_fractional(self):
         """Test deserializing a timedelta with fractional seconds."""
 
-        result = self.type_adapter._deserialize_value(f"v1:{_TypePrefix.TIMEDELTA}:1.5")
+        # timedelta(seconds=1.5) -> days=0, seconds=1, microseconds=500000
+        result = self.type_adapter._deserialize_value(f"v1:{_TypePrefix.TIMEDELTA}:0,1,500000")
 
         assert result == timedelta(seconds=1.5)
 

--- a/tests/unit/test_sqlalchemy_type.py
+++ b/tests/unit/test_sqlalchemy_type.py
@@ -59,6 +59,20 @@ class TestSerializeValue:
 
         assert result == f"{_TypePrefix.INT}:-123"
 
+    def test_serialize_bool_true(self):
+        """Test serializing boolean True."""
+
+        result = self.type_adapter._serialize_value(True)
+
+        assert result == f"{_TypePrefix.BOOL}:True"
+
+    def test_serialize_bool_false(self):
+        """Test serializing boolean False."""
+
+        result = self.type_adapter._serialize_value(False)
+
+        assert result == f"{_TypePrefix.BOOL}:False"
+
     def test_serialize_date(self):
         """Test serializing a date value."""
 
@@ -144,6 +158,22 @@ class TestDeserializeValue:
 
         assert result == -123
 
+    def test_deserialize_bool_true(self):
+        """Test deserializing boolean True."""
+
+        result = self.type_adapter._deserialize_value(f"{_TypePrefix.BOOL}:True")
+
+        assert result is True
+        assert isinstance(result, bool)
+
+    def test_deserialize_bool_false(self):
+        """Test deserializing boolean False."""
+
+        result = self.type_adapter._deserialize_value(f"{_TypePrefix.BOOL}:False")
+
+        assert result is False
+        assert isinstance(result, bool)
+
     def test_deserialize_date(self):
         """Test deserializing a date value."""
 
@@ -223,6 +253,28 @@ class TestSerializeDeserializeRoundTrip:
         result = self.type_adapter._deserialize_value(serialized)
 
         assert result == original
+
+    def test_roundtrip_bool_true(self):
+        """Test round-trip for boolean True."""
+
+        original = True
+
+        serialized = self.type_adapter._serialize_value(original)
+        result = self.type_adapter._deserialize_value(serialized)
+
+        assert result is True
+        assert isinstance(result, bool)
+
+    def test_roundtrip_bool_false(self):
+        """Test round-trip for boolean False."""
+
+        original = False
+
+        serialized = self.type_adapter._serialize_value(original)
+        result = self.type_adapter._deserialize_value(serialized)
+
+        assert result is False
+        assert isinstance(result, bool)
 
     def test_roundtrip_date(self):
         """Test round-trip for date."""

--- a/tests/unit/test_sqlalchemy_type.py
+++ b/tests/unit/test_sqlalchemy_type.py
@@ -1,0 +1,245 @@
+import base64
+from datetime import date, datetime, timezone
+
+import pytest
+
+from pydantic_encryption.integrations.sqlalchemy import SQLAlchemyEncrypted, _TypePrefix
+
+
+class TestSerializeValue:
+    """Test the _serialize_value method of SQLAlchemyEncrypted."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+
+        self.type_adapter = SQLAlchemyEncrypted()
+
+    def test_serialize_str(self):
+        """Test serializing a string value."""
+
+        result = self.type_adapter._serialize_value("hello world")
+
+        assert result == f"{_TypePrefix.STR}:hello world"
+
+    def test_serialize_str_with_colon(self):
+        """Test serializing a string with colon preserves the colon."""
+
+        result = self.type_adapter._serialize_value("hello:world")
+
+        assert result == f"{_TypePrefix.STR}:hello:world"
+
+    def test_serialize_bytes(self):
+        """Test serializing bytes value."""
+
+        test_bytes = b"\x00\x01\x02\x03binary\xff\xfe"
+
+        result = self.type_adapter._serialize_value(test_bytes)
+
+        expected_b64 = base64.b64encode(test_bytes).decode("ascii")
+        assert result == f"{_TypePrefix.BYTES}:{expected_b64}"
+
+    def test_serialize_bytes_empty(self):
+        """Test serializing empty bytes."""
+
+        result = self.type_adapter._serialize_value(b"")
+
+        assert result == f"{_TypePrefix.BYTES}:"
+
+    def test_serialize_int(self):
+        """Test serializing an integer value."""
+
+        result = self.type_adapter._serialize_value(42)
+
+        assert result == f"{_TypePrefix.INT}:42"
+
+    def test_serialize_int_negative(self):
+        """Test serializing a negative integer."""
+
+        result = self.type_adapter._serialize_value(-123)
+
+        assert result == f"{_TypePrefix.INT}:-123"
+
+    def test_serialize_date(self):
+        """Test serializing a date value."""
+
+        test_date = date(2025, 1, 21)
+
+        result = self.type_adapter._serialize_value(test_date)
+
+        assert result == f"{_TypePrefix.DATE}:2025-01-21"
+
+    def test_serialize_datetime(self):
+        """Test serializing a datetime value."""
+
+        test_datetime = datetime(2025, 1, 21, 14, 30, 45)
+
+        result = self.type_adapter._serialize_value(test_datetime)
+
+        assert result == f"{_TypePrefix.DATETIME}:2025-01-21T14:30:45"
+
+    def test_serialize_datetime_with_timezone(self):
+        """Test serializing a timezone-aware datetime."""
+
+        test_datetime = datetime(2025, 1, 21, 14, 30, 45, tzinfo=timezone.utc)
+
+        result = self.type_adapter._serialize_value(test_datetime)
+
+        assert result == f"{_TypePrefix.DATETIME}:2025-01-21T14:30:45+00:00"
+
+
+class TestDeserializeValue:
+    """Test the _deserialize_value method of SQLAlchemyEncrypted."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+
+        self.type_adapter = SQLAlchemyEncrypted()
+
+    def test_deserialize_str(self):
+        """Test deserializing a string value."""
+
+        result = self.type_adapter._deserialize_value(f"{_TypePrefix.STR}:hello world")
+
+        assert result == "hello world"
+        assert isinstance(result, str)
+
+    def test_deserialize_str_with_colon(self):
+        """Test deserializing a string with colon."""
+
+        result = self.type_adapter._deserialize_value(f"{_TypePrefix.STR}:hello:world")
+
+        assert result == "hello:world"
+
+    def test_deserialize_bytes(self):
+        """Test deserializing bytes value."""
+
+        test_bytes = b"\x00\x01\x02\x03binary\xff\xfe"
+        encoded = base64.b64encode(test_bytes).decode("ascii")
+
+        result = self.type_adapter._deserialize_value(f"{_TypePrefix.BYTES}:{encoded}")
+
+        assert result == test_bytes
+        assert isinstance(result, bytes)
+
+    def test_deserialize_bytes_empty(self):
+        """Test deserializing empty bytes."""
+
+        result = self.type_adapter._deserialize_value(f"{_TypePrefix.BYTES}:")
+
+        assert result == b""
+        assert isinstance(result, bytes)
+
+    def test_deserialize_int(self):
+        """Test deserializing an integer value."""
+
+        result = self.type_adapter._deserialize_value(f"{_TypePrefix.INT}:42")
+
+        assert result == 42
+        assert isinstance(result, int)
+
+    def test_deserialize_int_negative(self):
+        """Test deserializing a negative integer."""
+
+        result = self.type_adapter._deserialize_value(f"{_TypePrefix.INT}:-123")
+
+        assert result == -123
+
+    def test_deserialize_date(self):
+        """Test deserializing a date value."""
+
+        result = self.type_adapter._deserialize_value(f"{_TypePrefix.DATE}:2025-01-21")
+
+        assert result == date(2025, 1, 21)
+        assert isinstance(result, date)
+        assert not isinstance(result, datetime)
+
+    def test_deserialize_datetime(self):
+        """Test deserializing a datetime value."""
+
+        result = self.type_adapter._deserialize_value(f"{_TypePrefix.DATETIME}:2025-01-21T14:30:45")
+
+        assert result == datetime(2025, 1, 21, 14, 30, 45)
+        assert isinstance(result, datetime)
+
+    def test_deserialize_datetime_with_timezone(self):
+        """Test deserializing a timezone-aware datetime."""
+
+        result = self.type_adapter._deserialize_value(
+            f"{_TypePrefix.DATETIME}:2025-01-21T14:30:45+00:00"
+        )
+
+        assert result == datetime(2025, 1, 21, 14, 30, 45, tzinfo=timezone.utc)
+        assert result.tzinfo is not None
+
+    def test_deserialize_unknown_prefix_returns_original(self):
+        """Test that unknown prefix returns the original value unchanged."""
+
+        result = self.type_adapter._deserialize_value("unknown:some data")
+
+        assert result == "unknown:some data"
+
+    def test_deserialize_no_colon_returns_original(self):
+        """Test that value without colon returns the original value."""
+
+        result = self.type_adapter._deserialize_value("no_colon_here")
+
+        assert result == "no_colon_here"
+
+
+class TestSerializeDeserializeRoundTrip:
+    """Test round-trip serialization and deserialization."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+
+        self.type_adapter = SQLAlchemyEncrypted()
+
+    def test_roundtrip_str(self):
+        """Test round-trip for string."""
+
+        original = "hello world"
+
+        serialized = self.type_adapter._serialize_value(original)
+        result = self.type_adapter._deserialize_value(serialized)
+
+        assert result == original
+
+    def test_roundtrip_bytes(self):
+        """Test round-trip for bytes."""
+
+        original = b"\x00\x01\x02\x03binary\xff\xfe"
+
+        serialized = self.type_adapter._serialize_value(original)
+        result = self.type_adapter._deserialize_value(serialized)
+
+        assert result == original
+
+    def test_roundtrip_int(self):
+        """Test round-trip for integer."""
+
+        original = -12345
+
+        serialized = self.type_adapter._serialize_value(original)
+        result = self.type_adapter._deserialize_value(serialized)
+
+        assert result == original
+
+    def test_roundtrip_date(self):
+        """Test round-trip for date."""
+
+        original = date(2025, 1, 21)
+
+        serialized = self.type_adapter._serialize_value(original)
+        result = self.type_adapter._deserialize_value(serialized)
+
+        assert result == original
+
+    def test_roundtrip_datetime(self):
+        """Test round-trip for datetime."""
+
+        original = datetime(2025, 1, 21, 14, 30, 45, tzinfo=timezone.utc)
+
+        serialized = self.type_adapter._serialize_value(original)
+        result = self.type_adapter._deserialize_value(serialized)
+
+        assert result == original

--- a/tests/unit/test_sqlalchemy_type.py
+++ b/tests/unit/test_sqlalchemy_type.py
@@ -136,7 +136,8 @@ class TestSerializeValue:
 
         result = self.type_adapter._serialize_value(test_timedelta)
 
-        assert result == f"v1:{_TypePrefix.TIMEDELTA}:{test_timedelta.total_seconds()}"
+        # Format: days,seconds,microseconds to preserve precision
+        assert result == f"v1:{_TypePrefix.TIMEDELTA}:{test_timedelta.days},{test_timedelta.seconds},{test_timedelta.microseconds}"
 
     def test_serialize_timedelta_negative(self):
         """Test serializing a negative timedelta."""
@@ -145,16 +146,18 @@ class TestSerializeValue:
 
         result = self.type_adapter._serialize_value(test_timedelta)
 
-        assert result == f"v1:{_TypePrefix.TIMEDELTA}:{test_timedelta.total_seconds()}"
+        # Format: days,seconds,microseconds to preserve precision
+        assert result == f"v1:{_TypePrefix.TIMEDELTA}:{test_timedelta.days},{test_timedelta.seconds},{test_timedelta.microseconds}"
 
     def test_serialize_timedelta_fractional(self):
-        """Test serializing a timedelta with fractional seconds."""
+        """Test serializing a timedelta with fractional seconds (stored as microseconds)."""
 
         test_timedelta = timedelta(seconds=1.5)
 
         result = self.type_adapter._serialize_value(test_timedelta)
 
-        assert result == f"v1:{_TypePrefix.TIMEDELTA}:1.5"
+        # Format: days,seconds,microseconds - fractional seconds become microseconds
+        assert result == f"v1:{_TypePrefix.TIMEDELTA}:{test_timedelta.days},{test_timedelta.seconds},{test_timedelta.microseconds}"
 
     def test_serialize_float(self):
         """Test serializing a float value."""

--- a/tests/unit/test_sqlalchemy_type.py
+++ b/tests/unit/test_sqlalchemy_type.py
@@ -1,5 +1,7 @@
 import base64
-from datetime import date, datetime, timezone
+from datetime import date, datetime, time, timedelta, timezone
+from decimal import Decimal
+from uuid import UUID
 
 import pytest
 
@@ -19,14 +21,14 @@ class TestSerializeValue:
 
         result = self.type_adapter._serialize_value("hello world")
 
-        assert result == f"{_TypePrefix.STR}:hello world"
+        assert result == f"v1:{_TypePrefix.STR}:hello world"
 
     def test_serialize_str_with_colon(self):
         """Test serializing a string with colon preserves the colon."""
 
         result = self.type_adapter._serialize_value("hello:world")
 
-        assert result == f"{_TypePrefix.STR}:hello:world"
+        assert result == f"v1:{_TypePrefix.STR}:hello:world"
 
     def test_serialize_bytes(self):
         """Test serializing bytes value."""
@@ -36,42 +38,42 @@ class TestSerializeValue:
         result = self.type_adapter._serialize_value(test_bytes)
 
         expected_b64 = base64.b64encode(test_bytes).decode("ascii")
-        assert result == f"{_TypePrefix.BYTES}:{expected_b64}"
+        assert result == f"v1:{_TypePrefix.BYTES}:{expected_b64}"
 
     def test_serialize_bytes_empty(self):
         """Test serializing empty bytes."""
 
         result = self.type_adapter._serialize_value(b"")
 
-        assert result == f"{_TypePrefix.BYTES}:"
+        assert result == f"v1:{_TypePrefix.BYTES}:"
 
     def test_serialize_int(self):
         """Test serializing an integer value."""
 
         result = self.type_adapter._serialize_value(42)
 
-        assert result == f"{_TypePrefix.INT}:42"
+        assert result == f"v1:{_TypePrefix.INT}:42"
 
     def test_serialize_int_negative(self):
         """Test serializing a negative integer."""
 
         result = self.type_adapter._serialize_value(-123)
 
-        assert result == f"{_TypePrefix.INT}:-123"
+        assert result == f"v1:{_TypePrefix.INT}:-123"
 
     def test_serialize_bool_true(self):
         """Test serializing boolean True."""
 
         result = self.type_adapter._serialize_value(True)
 
-        assert result == f"{_TypePrefix.BOOL}:True"
+        assert result == f"v1:{_TypePrefix.BOOL}:true"
 
     def test_serialize_bool_false(self):
         """Test serializing boolean False."""
 
         result = self.type_adapter._serialize_value(False)
 
-        assert result == f"{_TypePrefix.BOOL}:False"
+        assert result == f"v1:{_TypePrefix.BOOL}:false"
 
     def test_serialize_date(self):
         """Test serializing a date value."""
@@ -80,7 +82,7 @@ class TestSerializeValue:
 
         result = self.type_adapter._serialize_value(test_date)
 
-        assert result == f"{_TypePrefix.DATE}:2025-01-21"
+        assert result == f"v1:{_TypePrefix.DATE}:2025-01-21"
 
     def test_serialize_datetime(self):
         """Test serializing a datetime value."""
@@ -89,7 +91,7 @@ class TestSerializeValue:
 
         result = self.type_adapter._serialize_value(test_datetime)
 
-        assert result == f"{_TypePrefix.DATETIME}:2025-01-21T14:30:45"
+        assert result == f"v1:{_TypePrefix.DATETIME}:2025-01-21T14:30:45"
 
     def test_serialize_datetime_with_timezone(self):
         """Test serializing a timezone-aware datetime."""
@@ -98,7 +100,118 @@ class TestSerializeValue:
 
         result = self.type_adapter._serialize_value(test_datetime)
 
-        assert result == f"{_TypePrefix.DATETIME}:2025-01-21T14:30:45+00:00"
+        assert result == f"v1:{_TypePrefix.DATETIME}:2025-01-21T14:30:45+00:00"
+
+    def test_serialize_time(self):
+        """Test serializing a time value."""
+
+        test_time = time(14, 30, 45)
+
+        result = self.type_adapter._serialize_value(test_time)
+
+        assert result == f"v1:{_TypePrefix.TIME}:14:30:45"
+
+    def test_serialize_time_with_microseconds(self):
+        """Test serializing a time with microseconds."""
+
+        test_time = time(14, 30, 45, 123456)
+
+        result = self.type_adapter._serialize_value(test_time)
+
+        assert result == f"v1:{_TypePrefix.TIME}:14:30:45.123456"
+
+    def test_serialize_time_with_timezone(self):
+        """Test serializing a timezone-aware time."""
+
+        test_time = time(14, 30, 45, tzinfo=timezone.utc)
+
+        result = self.type_adapter._serialize_value(test_time)
+
+        assert result == f"v1:{_TypePrefix.TIME}:14:30:45+00:00"
+
+    def test_serialize_timedelta(self):
+        """Test serializing a timedelta value."""
+
+        test_timedelta = timedelta(days=1, hours=2, minutes=30, seconds=45)
+
+        result = self.type_adapter._serialize_value(test_timedelta)
+
+        assert result == f"v1:{_TypePrefix.TIMEDELTA}:{test_timedelta.total_seconds()}"
+
+    def test_serialize_timedelta_negative(self):
+        """Test serializing a negative timedelta."""
+
+        test_timedelta = timedelta(days=-1, hours=-2)
+
+        result = self.type_adapter._serialize_value(test_timedelta)
+
+        assert result == f"v1:{_TypePrefix.TIMEDELTA}:{test_timedelta.total_seconds()}"
+
+    def test_serialize_timedelta_fractional(self):
+        """Test serializing a timedelta with fractional seconds."""
+
+        test_timedelta = timedelta(seconds=1.5)
+
+        result = self.type_adapter._serialize_value(test_timedelta)
+
+        assert result == f"v1:{_TypePrefix.TIMEDELTA}:1.5"
+
+    def test_serialize_float(self):
+        """Test serializing a float value."""
+
+        result = self.type_adapter._serialize_value(3.14159)
+
+        assert result == f"v1:{_TypePrefix.FLOAT}:3.14159"
+
+    def test_serialize_float_negative(self):
+        """Test serializing a negative float."""
+
+        result = self.type_adapter._serialize_value(-2.5)
+
+        assert result == f"v1:{_TypePrefix.FLOAT}:-2.5"
+
+    def test_serialize_float_scientific(self):
+        """Test serializing a float in scientific notation."""
+
+        result = self.type_adapter._serialize_value(1e-10)
+
+        assert result == f"v1:{_TypePrefix.FLOAT}:1e-10"
+
+    def test_serialize_decimal(self):
+        """Test serializing a Decimal value."""
+
+        test_decimal = Decimal("123.456789")
+
+        result = self.type_adapter._serialize_value(test_decimal)
+
+        assert result == f"v1:{_TypePrefix.DECIMAL}:123.456789"
+
+    def test_serialize_decimal_high_precision(self):
+        """Test serializing a high-precision Decimal."""
+
+        test_decimal = Decimal("0.123456789012345678901234567890")
+
+        result = self.type_adapter._serialize_value(test_decimal)
+
+        assert result == f"v1:{_TypePrefix.DECIMAL}:0.123456789012345678901234567890"
+
+    def test_serialize_decimal_negative(self):
+        """Test serializing a negative Decimal."""
+
+        test_decimal = Decimal("-999.99")
+
+        result = self.type_adapter._serialize_value(test_decimal)
+
+        assert result == f"v1:{_TypePrefix.DECIMAL}:-999.99"
+
+    def test_serialize_uuid(self):
+        """Test serializing a UUID value."""
+
+        test_uuid = UUID("12345678-1234-5678-1234-567812345678")
+
+        result = self.type_adapter._serialize_value(test_uuid)
+
+        assert result == f"v1:{_TypePrefix.UUID}:12345678-1234-5678-1234-567812345678"
 
 
 class TestDeserializeValue:
@@ -112,7 +225,7 @@ class TestDeserializeValue:
     def test_deserialize_str(self):
         """Test deserializing a string value."""
 
-        result = self.type_adapter._deserialize_value(f"{_TypePrefix.STR}:hello world")
+        result = self.type_adapter._deserialize_value(f"v1:{_TypePrefix.STR}:hello world")
 
         assert result == "hello world"
         assert isinstance(result, str)
@@ -120,7 +233,7 @@ class TestDeserializeValue:
     def test_deserialize_str_with_colon(self):
         """Test deserializing a string with colon."""
 
-        result = self.type_adapter._deserialize_value(f"{_TypePrefix.STR}:hello:world")
+        result = self.type_adapter._deserialize_value(f"v1:{_TypePrefix.STR}:hello:world")
 
         assert result == "hello:world"
 
@@ -130,7 +243,7 @@ class TestDeserializeValue:
         test_bytes = b"\x00\x01\x02\x03binary\xff\xfe"
         encoded = base64.b64encode(test_bytes).decode("ascii")
 
-        result = self.type_adapter._deserialize_value(f"{_TypePrefix.BYTES}:{encoded}")
+        result = self.type_adapter._deserialize_value(f"v1:{_TypePrefix.BYTES}:{encoded}")
 
         assert result == test_bytes
         assert isinstance(result, bytes)
@@ -138,7 +251,7 @@ class TestDeserializeValue:
     def test_deserialize_bytes_empty(self):
         """Test deserializing empty bytes."""
 
-        result = self.type_adapter._deserialize_value(f"{_TypePrefix.BYTES}:")
+        result = self.type_adapter._deserialize_value(f"v1:{_TypePrefix.BYTES}:")
 
         assert result == b""
         assert isinstance(result, bytes)
@@ -146,7 +259,7 @@ class TestDeserializeValue:
     def test_deserialize_int(self):
         """Test deserializing an integer value."""
 
-        result = self.type_adapter._deserialize_value(f"{_TypePrefix.INT}:42")
+        result = self.type_adapter._deserialize_value(f"v1:{_TypePrefix.INT}:42")
 
         assert result == 42
         assert isinstance(result, int)
@@ -154,14 +267,14 @@ class TestDeserializeValue:
     def test_deserialize_int_negative(self):
         """Test deserializing a negative integer."""
 
-        result = self.type_adapter._deserialize_value(f"{_TypePrefix.INT}:-123")
+        result = self.type_adapter._deserialize_value(f"v1:{_TypePrefix.INT}:-123")
 
         assert result == -123
 
     def test_deserialize_bool_true(self):
         """Test deserializing boolean True."""
 
-        result = self.type_adapter._deserialize_value(f"{_TypePrefix.BOOL}:True")
+        result = self.type_adapter._deserialize_value(f"v1:{_TypePrefix.BOOL}:true")
 
         assert result is True
         assert isinstance(result, bool)
@@ -169,7 +282,7 @@ class TestDeserializeValue:
     def test_deserialize_bool_false(self):
         """Test deserializing boolean False."""
 
-        result = self.type_adapter._deserialize_value(f"{_TypePrefix.BOOL}:False")
+        result = self.type_adapter._deserialize_value(f"v1:{_TypePrefix.BOOL}:false")
 
         assert result is False
         assert isinstance(result, bool)
@@ -177,7 +290,7 @@ class TestDeserializeValue:
     def test_deserialize_date(self):
         """Test deserializing a date value."""
 
-        result = self.type_adapter._deserialize_value(f"{_TypePrefix.DATE}:2025-01-21")
+        result = self.type_adapter._deserialize_value(f"v1:{_TypePrefix.DATE}:2025-01-21")
 
         assert result == date(2025, 1, 21)
         assert isinstance(result, date)
@@ -186,7 +299,7 @@ class TestDeserializeValue:
     def test_deserialize_datetime(self):
         """Test deserializing a datetime value."""
 
-        result = self.type_adapter._deserialize_value(f"{_TypePrefix.DATETIME}:2025-01-21T14:30:45")
+        result = self.type_adapter._deserialize_value(f"v1:{_TypePrefix.DATETIME}:2025-01-21T14:30:45")
 
         assert result == datetime(2025, 1, 21, 14, 30, 45)
         assert isinstance(result, datetime)
@@ -195,25 +308,130 @@ class TestDeserializeValue:
         """Test deserializing a timezone-aware datetime."""
 
         result = self.type_adapter._deserialize_value(
-            f"{_TypePrefix.DATETIME}:2025-01-21T14:30:45+00:00"
+            f"v1:{_TypePrefix.DATETIME}:2025-01-21T14:30:45+00:00"
         )
 
         assert result == datetime(2025, 1, 21, 14, 30, 45, tzinfo=timezone.utc)
         assert result.tzinfo is not None
 
-    def test_deserialize_unknown_prefix_returns_original(self):
-        """Test that unknown prefix returns the original value unchanged."""
+    def test_deserialize_time(self):
+        """Test deserializing a time value."""
 
-        result = self.type_adapter._deserialize_value("unknown:some data")
+        result = self.type_adapter._deserialize_value(f"v1:{_TypePrefix.TIME}:14:30:45")
 
-        assert result == "unknown:some data"
+        assert result == time(14, 30, 45)
+        assert isinstance(result, time)
 
-    def test_deserialize_no_colon_returns_original(self):
-        """Test that value without colon returns the original value."""
+    def test_deserialize_time_with_microseconds(self):
+        """Test deserializing a time with microseconds."""
 
-        result = self.type_adapter._deserialize_value("no_colon_here")
+        result = self.type_adapter._deserialize_value(f"v1:{_TypePrefix.TIME}:14:30:45.123456")
 
-        assert result == "no_colon_here"
+        assert result == time(14, 30, 45, 123456)
+
+    def test_deserialize_time_with_timezone(self):
+        """Test deserializing a timezone-aware time."""
+
+        result = self.type_adapter._deserialize_value(f"v1:{_TypePrefix.TIME}:14:30:45+00:00")
+
+        assert result == time(14, 30, 45, tzinfo=timezone.utc)
+        assert result.tzinfo is not None
+
+    def test_deserialize_timedelta(self):
+        """Test deserializing a timedelta value."""
+
+        result = self.type_adapter._deserialize_value(f"v1:{_TypePrefix.TIMEDELTA}:95445.0")
+
+        assert result == timedelta(days=1, hours=2, minutes=30, seconds=45)
+        assert isinstance(result, timedelta)
+
+    def test_deserialize_timedelta_negative(self):
+        """Test deserializing a negative timedelta."""
+
+        result = self.type_adapter._deserialize_value(f"v1:{_TypePrefix.TIMEDELTA}:-93600.0")
+
+        assert result == timedelta(days=-1, hours=-2)
+
+    def test_deserialize_timedelta_fractional(self):
+        """Test deserializing a timedelta with fractional seconds."""
+
+        result = self.type_adapter._deserialize_value(f"v1:{_TypePrefix.TIMEDELTA}:1.5")
+
+        assert result == timedelta(seconds=1.5)
+
+    def test_deserialize_float(self):
+        """Test deserializing a float value."""
+
+        result = self.type_adapter._deserialize_value(f"v1:{_TypePrefix.FLOAT}:3.14159")
+
+        assert result == 3.14159
+        assert isinstance(result, float)
+
+    def test_deserialize_float_negative(self):
+        """Test deserializing a negative float."""
+
+        result = self.type_adapter._deserialize_value(f"v1:{_TypePrefix.FLOAT}:-2.5")
+
+        assert result == -2.5
+
+    def test_deserialize_float_scientific(self):
+        """Test deserializing a float in scientific notation."""
+
+        result = self.type_adapter._deserialize_value(f"v1:{_TypePrefix.FLOAT}:1e-10")
+
+        assert result == 1e-10
+
+    def test_deserialize_decimal(self):
+        """Test deserializing a Decimal value."""
+
+        result = self.type_adapter._deserialize_value(f"v1:{_TypePrefix.DECIMAL}:123.456789")
+
+        assert result == Decimal("123.456789")
+        assert isinstance(result, Decimal)
+
+    def test_deserialize_decimal_high_precision(self):
+        """Test deserializing a high-precision Decimal."""
+
+        result = self.type_adapter._deserialize_value(
+            f"v1:{_TypePrefix.DECIMAL}:0.123456789012345678901234567890"
+        )
+
+        assert result == Decimal("0.123456789012345678901234567890")
+
+    def test_deserialize_decimal_negative(self):
+        """Test deserializing a negative Decimal."""
+
+        result = self.type_adapter._deserialize_value(f"v1:{_TypePrefix.DECIMAL}:-999.99")
+
+        assert result == Decimal("-999.99")
+
+    def test_deserialize_uuid(self):
+        """Test deserializing a UUID value."""
+
+        result = self.type_adapter._deserialize_value(
+            f"v1:{_TypePrefix.UUID}:12345678-1234-5678-1234-567812345678"
+        )
+
+        assert result == UUID("12345678-1234-5678-1234-567812345678")
+        assert isinstance(result, UUID)
+
+    def test_deserialize_legacy_format_raises_error(self):
+        """Test that legacy format without version marker raises RuntimeError."""
+
+        with pytest.raises(RuntimeError, match="Unknown version"):
+            self.type_adapter._deserialize_value("str:hello world")
+
+    def test_deserialize_unknown_version_raises_error(self):
+        """Test that unknown version raises RuntimeError."""
+
+        with pytest.raises(RuntimeError, match="Unknown version"):
+            self.type_adapter._deserialize_value("v2:str:hello world")
+
+    def test_deserialize_no_colon_raises_error(self):
+        """Test that value without colon raises RuntimeError."""
+
+        with pytest.raises(RuntimeError, match="Unknown version"):
+            self.type_adapter._deserialize_value("no_colon_here")
 
 
 class TestSerializeDeserializeRoundTrip:
@@ -295,3 +513,65 @@ class TestSerializeDeserializeRoundTrip:
         result = self.type_adapter._deserialize_value(serialized)
 
         assert result == original
+
+    def test_roundtrip_time(self):
+        """Test round-trip for time."""
+
+        original = time(14, 30, 45, 123456, tzinfo=timezone.utc)
+
+        serialized = self.type_adapter._serialize_value(original)
+        result = self.type_adapter._deserialize_value(serialized)
+
+        assert result == original
+
+    def test_roundtrip_timedelta(self):
+        """Test round-trip for timedelta."""
+
+        original = timedelta(days=5, hours=3, minutes=30, seconds=45, microseconds=123456)
+
+        serialized = self.type_adapter._serialize_value(original)
+        result = self.type_adapter._deserialize_value(serialized)
+
+        assert result == original
+
+    def test_roundtrip_timedelta_negative(self):
+        """Test round-trip for negative timedelta."""
+
+        original = timedelta(days=-10, hours=-5)
+
+        serialized = self.type_adapter._serialize_value(original)
+        result = self.type_adapter._deserialize_value(serialized)
+
+        assert result == original
+
+    def test_roundtrip_float(self):
+        """Test round-trip for float."""
+
+        original = 3.141592653589793
+
+        serialized = self.type_adapter._serialize_value(original)
+        result = self.type_adapter._deserialize_value(serialized)
+
+        assert result == original
+
+    def test_roundtrip_decimal(self):
+        """Test round-trip for Decimal."""
+
+        original = Decimal("123.456789012345678901234567890")
+
+        serialized = self.type_adapter._serialize_value(original)
+        result = self.type_adapter._deserialize_value(serialized)
+
+        assert result == original
+        assert isinstance(result, Decimal)
+
+    def test_roundtrip_uuid(self):
+        """Test round-trip for UUID."""
+
+        original = UUID("12345678-1234-5678-1234-567812345678")
+
+        serialized = self.type_adapter._serialize_value(original)
+        result = self.type_adapter._deserialize_value(serialized)
+
+        assert result == original
+        assert isinstance(result, UUID)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Enhances SQLAlchemy encryption with native type preservation**
> 
> - Introduces versioned, type-aware serialization in `SQLAlchemyEncrypted` (`v1:type:data`) to support `str`, `bytes`, `bool`, `int`, `float`, `Decimal`, `UUID`, `date`, `datetime`, `time`, and `timedelta`
> - Encryption now operates on serialized strings and decryption deserializes back to native types; removes `DecryptedValue` wrapper and updates `process_*` signatures/return types
> - Adds extensive unit and integration tests covering all supported types, timezone-aware `datetime`/`time`, and edge cases (negatives, high precision)
> - Updates README with a "Supported Types" section and examples; bumps package version to `0.3.0`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 11ce22d0717705cf40cf3dbe2682772029d144c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->