### PR TITLE
Upgrade to pydantic-super-model v2 with SuperModelPydanticMixin

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1284,14 +1284,14 @@ yaml = ["pyyaml (>=6.0.1)"]
 
 [[package]]
 name = "pydantic-super-model"
-version = "1.2.0"
-description = "Small Pydantic BaseModel extension for generic introspection and Annotated field lookup"
+version = "2.0.0"
+description = "Lightweight mixin for generic introspection and Annotated field lookup"
 optional = false
 python-versions = "<3.15,>=3.11"
 groups = ["main"]
 files = [
-    {file = "pydantic_super_model-1.2.0-py3-none-any.whl", hash = "sha256:52eed3cb2cd0f895dba6304212f776a81e1942e15f0e2be1f4adf22f0e9bca7a"},
-    {file = "pydantic_super_model-1.2.0.tar.gz", hash = "sha256:5e14cb40965741c0b173f11b8a7f5474461f4f7fed96771ff8416f43cfe67716"},
+    {file = "pydantic_super_model-2.0.0-py3-none-any.whl", hash = "sha256:2284d598d061b7ed473b96704575d749f3b23dfbb4bd78e074af589c6fb67a84"},
+    {file = "pydantic_super_model-2.0.0.tar.gz", hash = "sha256:3bb026160c279c9de1f2e4c36fd677b4f63c6835bce64591a924d96ba3623e60"},
 ]
 
 [package.dependencies]
@@ -1885,4 +1885,4 @@ sqlalchemy = ["sqlalchemy", "sqlmodel"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.15"
-content-hash = "d85507014097297292a93cca5e12b46e731af02a8aa56cf1b21df465c0233a7d"
+content-hash = "e42c59611c162b1af4150d5c82353fc21f6f81eb6b089ddc831ae9af432e7ec4"

--- a/pydantic_encryption/models/base.py
+++ b/pydantic_encryption/models/base.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from pydantic_super_model import AnnotatedFieldInfo, SuperModel
+from pydantic_super_model import AnnotatedFieldInfo, SuperModelPydanticMixin
 
 from pydantic_encryption.adapters import blind_index, encryption, hashing
 from pydantic_encryption.config import settings
@@ -213,7 +213,7 @@ class SecureModel:
         return self.get_annotated_fields(BlindIndex)
 
 
-class BaseModel(SuperModel, SecureModel):
+class BaseModel(SuperModelPydanticMixin, SecureModel):
     """Base model for encryptable models."""
 
     def get_annotated_fields(self, *annotations: type) -> dict[str, AnnotatedFieldInfo]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ requires-python = ">=3.11,<3.15"
 dependencies = [
     "pydantic>=2.10.6",
     "pydantic-settings>=2.9.1",
-    "pydantic-super-model>=1.2.0",
+    "pydantic-super-model>=2.0.0",
     "cryptography>=44.0.0",
     "argon2-cffi>=23.1.0",
 ]


### PR DESCRIPTION
## Summary
This PR upgrades the `pydantic-super-model` dependency to v2.0.0 and updates the codebase to use the new `SuperModelPydanticMixin` class that replaces the previous `SuperModel` class.

## Key Changes
- Updated `pydantic-super-model` dependency from `>=1.2.0` to `>=2.0.0` in `pyproject.toml`
- Replaced import of `SuperModel` with `SuperModelPydanticMixin` in `pydantic_encryption/models/base.py`
- Updated `BaseModel` class to inherit from `SuperModelPydanticMixin` instead of `SuperModel`

## Implementation Details
The changes reflect a breaking API change in the `pydantic-super-model` library where `SuperModel` has been renamed to `SuperModelPydanticMixin`. This is a straightforward migration that maintains the same functionality while adopting the new naming convention from the upstream library.

https://claude.ai/code/session_011u19hdQZ3Vh2DQDauzypWa

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it upgrades a core modeling dependency and changes `BaseModel` inheritance, which could subtly affect annotated-field introspection and `model_post_init` behavior across consumers.
> 
> **Overview**
> Upgrades the `pydantic-super-model` dependency to `>=2.0.0` (including lockfile updates).
> 
> Migrates `pydantic_encryption.models.BaseModel` from `SuperModel` to `SuperModelPydanticMixin`, updating imports and the inheritance chain while keeping `get_annotated_fields`/`model_post_init` wired through to the upstream mixin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7c61095f0fc431e1c259565c7ef4488c06068db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->