### PR TITLE
claude/fix-async-decrypt-refactor-5zcuX

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,31 +241,28 @@ SQLAlchemy's `TypeDecorator` is sync by contract — even under `AsyncSession` t
 
 **Tier 1 — automatic, zero code change.** Under `AsyncSession`, decryption transparently uses SQLAlchemy's greenlet bridge (`sqlalchemy.util.await_`) so each decrypt yields the event loop during its network roundtrip. Other tasks on the loop keep progressing. The same bridge also wraps Argon2 hashing (`SQLAlchemyHashedValue`) and Argon2 blind-index computation (`SQLAlchemyBlindIndexValue`) so write-side commits don't block either.
 
-**Tier 2 — opt-in, real parallelism.** For single fetches with many encrypted cells, pass `defer_decrypt=True` on the column and bulk-decrypt after the fetch. Every cell is decrypted concurrently via `asyncio.gather`, turning N sequential roundtrips into one concurrent burst.
+**Tier 2 — opt-in, real parallelism.** For single fetches with many encrypted cells, inherit `DeferredDecryptMixin` on the model and every `SQLAlchemyEncryptedValue` column on that class automatically defers decryption — reads return `EncryptedValue(bytes)` instead of plaintext. Bulk-decrypt after the fetch via `async_decrypt_rows` or the mixin helpers (`decrypt()`, `decrypt_many()`, `scalar_one_or_none()`, `scalars_all()`). Every cell is decrypted concurrently via `asyncio.gather`, turning N sequential roundtrips into one concurrent burst.
 
 ```python
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from pydantic_encryption import async_decrypt_rows, SQLAlchemyEncryptedValue
+from pydantic_encryption import DeferredDecryptMixin, SQLAlchemyEncryptedValue
 
-class User(Base):
+class User(Base, DeferredDecryptMixin):
     __tablename__ = "users"
     id: Mapped[int] = mapped_column(primary_key=True)
-    email: Mapped[bytes] = mapped_column(SQLAlchemyEncryptedValue(defer_decrypt=True))
-    secret: Mapped[bytes] = mapped_column(SQLAlchemyEncryptedValue(defer_decrypt=True))
+    email: Mapped[bytes] = mapped_column(SQLAlchemyEncryptedValue())
+    secret: Mapped[bytes] = mapped_column(SQLAlchemyEncryptedValue())
 
 
 async with AsyncSession(engine) as session:
-    users = (await session.execute(select(User).limit(1000))).scalars().all()
-
-    # Before this call, users[i].email is still an EncryptedValue.
-    await async_decrypt_rows(users, User.email, User.secret)
+    users = await User.scalars_all(session, select(User).limit(1000))
 
     for u in users:
         print(u.email)  # decrypted plaintext
 ```
 
-`async_decrypt_rows` accepts `InstrumentedAttribute` (e.g. `User.email`) or string column names. Pass `concurrency=N` to cap in-flight decrypts with an `asyncio.Semaphore`.
+`scalar_one_or_none` / `scalars_all` wrap `session.execute(...)` and decrypt in one step. `async_decrypt_rows` is the lower-level primitive — it accepts `InstrumentedAttribute` (e.g. `User.email`) or string column names and takes a `concurrency=N` kwarg to cap in-flight decrypts with an `asyncio.Semaphore`.
 
 ## Custom Encryption or Hashing
 

--- a/pydantic_encryption/__init__.py
+++ b/pydantic_encryption/__init__.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
         SQLAlchemyHashedValue,
         SQLAlchemyPGEncryptedArray,
     )
-    from pydantic_encryption.integrations.sqlalchemy.bulk import async_decrypt_rows
+    from pydantic_encryption.integrations.sqlalchemy.bulk import DeferredDecryptMixin, async_decrypt_rows
 
 
 def __getattr__(name: str):
@@ -58,6 +58,11 @@ def __getattr__(name: str):
         from pydantic_encryption.integrations.sqlalchemy.bulk import async_decrypt_rows
 
         return async_decrypt_rows
+
+    if name == "DeferredDecryptMixin":
+        from pydantic_encryption.integrations.sqlalchemy.bulk import DeferredDecryptMixin
+
+        return DeferredDecryptMixin
 
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
@@ -93,4 +98,5 @@ __all__ = [
     "SQLAlchemyPGEncryptedArray",
     "SQLAlchemyHashedValue",
     "async_decrypt_rows",
+    "DeferredDecryptMixin",
 ]

--- a/pydantic_encryption/integrations/sqlalchemy/__init__.py
+++ b/pydantic_encryption/integrations/sqlalchemy/__init__.py
@@ -6,8 +6,10 @@ from pydantic_encryption.integrations.sqlalchemy.bulk import (
 )
 from pydantic_encryption.integrations.sqlalchemy.encryption import SQLAlchemyEncryptedValue, SQLAlchemyPGEncryptedArray
 from pydantic_encryption.integrations.sqlalchemy.hashing import SQLAlchemyHashedValue
+from pydantic_encryption.integrations.sqlalchemy.session import AutoDecryptAsyncSession
 
 __all__ = [
+    "AutoDecryptAsyncSession",
     "DeferredDecryptMixin",
     "SQLAlchemyBlindIndexValue",
     "SQLAlchemyEncryptedValue",

--- a/pydantic_encryption/integrations/sqlalchemy/__init__.py
+++ b/pydantic_encryption/integrations/sqlalchemy/__init__.py
@@ -1,9 +1,10 @@
 from pydantic_encryption.integrations.sqlalchemy.blind_index import SQLAlchemyBlindIndexValue
-from pydantic_encryption.integrations.sqlalchemy.bulk import async_decrypt_rows
+from pydantic_encryption.integrations.sqlalchemy.bulk import DeferredDecryptMixin, async_decrypt_rows
 from pydantic_encryption.integrations.sqlalchemy.encryption import SQLAlchemyEncryptedValue, SQLAlchemyPGEncryptedArray
 from pydantic_encryption.integrations.sqlalchemy.hashing import SQLAlchemyHashedValue
 
 __all__ = [
+    "DeferredDecryptMixin",
     "SQLAlchemyBlindIndexValue",
     "SQLAlchemyEncryptedValue",
     "SQLAlchemyPGEncryptedArray",

--- a/pydantic_encryption/integrations/sqlalchemy/__init__.py
+++ b/pydantic_encryption/integrations/sqlalchemy/__init__.py
@@ -1,5 +1,9 @@
 from pydantic_encryption.integrations.sqlalchemy.blind_index import SQLAlchemyBlindIndexValue
-from pydantic_encryption.integrations.sqlalchemy.bulk import DeferredDecryptMixin, async_decrypt_rows
+from pydantic_encryption.integrations.sqlalchemy.bulk import (
+    DeferredDecryptMixin,
+    async_decrypt_rows,
+    async_decrypt_values,
+)
 from pydantic_encryption.integrations.sqlalchemy.encryption import SQLAlchemyEncryptedValue, SQLAlchemyPGEncryptedArray
 from pydantic_encryption.integrations.sqlalchemy.hashing import SQLAlchemyHashedValue
 
@@ -10,4 +14,5 @@ __all__ = [
     "SQLAlchemyPGEncryptedArray",
     "SQLAlchemyHashedValue",
     "async_decrypt_rows",
+    "async_decrypt_values",
 ]

--- a/pydantic_encryption/integrations/sqlalchemy/bulk.py
+++ b/pydantic_encryption/integrations/sqlalchemy/bulk.py
@@ -1,5 +1,6 @@
 import asyncio
-from typing import Any, Iterable, Self
+from collections.abc import Iterable
+from typing import Any, Self
 
 from pydantic_encryption._lazy import require_optional_dependency
 
@@ -108,7 +109,7 @@ def _collect_encrypted_cells(
     if entities is None:
         return
 
-    if isinstance(entities, (list, tuple, set, frozenset)):
+    if isinstance(entities, Iterable) and not isinstance(entities, (str, bytes, bytearray)):
         items = list(entities)
     else:
         items = [entities]

--- a/pydantic_encryption/integrations/sqlalchemy/bulk.py
+++ b/pydantic_encryption/integrations/sqlalchemy/bulk.py
@@ -5,7 +5,7 @@ from pydantic_encryption._lazy import require_optional_dependency
 
 require_optional_dependency("sqlalchemy", "sqlalchemy")
 
-from sqlalchemy import Select, inspect as sa_inspect
+from sqlalchemy import Select, event, inspect as sa_inspect
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm.attributes import InstrumentedAttribute
 
@@ -132,7 +132,7 @@ def _collect_encrypted_cells(
             if not isinstance(column.type, SQLAlchemyEncryptedValue):
                 continue
 
-            if not column.type.defer_decrypt:
+            if not column.type._deferred:
                 continue
 
             value = state.dict.get(column.key)
@@ -156,8 +156,28 @@ def _collect_encrypted_cells(
                 _collect_encrypted_cells(related, collected, visited)
 
 
+def _mark_encrypted_columns_deferred(mapper, class_) -> None:
+    for column in mapper.columns:
+        if not isinstance(column.type, SQLAlchemyEncryptedValue):
+            continue
+        if column.type._deferred:
+            continue
+        column.type = column.type.copy()
+        column.type._deferred = True
+
+
 class DeferredDecryptMixin:
-    """Mixin that adds async decrypt helpers for deferred SQLAlchemyEncryptedValue columns."""
+    """Mixin that auto-defers SQLAlchemyEncryptedValue columns and adds async decrypt helpers.
+
+    Every ``SQLAlchemyEncryptedValue`` column on a class that inherits this mixin returns
+    ``EncryptedValue(bytes)`` on read instead of plaintext; call ``decrypt()`` /
+    ``decrypt_many()`` / ``scalar_one_or_none()`` / ``scalars_all()`` to decrypt in bulk.
+    ``SQLAlchemyPGEncryptedArray`` columns are not affected and still decrypt inline.
+    """
+
+    def __init_subclass__(cls, **kwargs) -> None:
+        super().__init_subclass__(**kwargs)
+        event.listen(cls, "mapper_configured", _mark_encrypted_columns_deferred)
 
     async def decrypt(self) -> Self:
         """Decrypt deferred encrypted columns on this instance and any loaded relationships."""

--- a/pydantic_encryption/integrations/sqlalchemy/bulk.py
+++ b/pydantic_encryption/integrations/sqlalchemy/bulk.py
@@ -236,6 +236,8 @@ def _mark_encrypted_columns_deferred(mapper, class_) -> None:
 def _on_orm_load(instance: Any, context: Any) -> None:
     """Collect freshly loaded DeferredDecryptMixin instances into the session's pending bucket."""
 
+    if context is None:
+        return
     session = context.session
     if session is None or not session.info.get(AUTO_DECRYPT_ENABLED_KEY):
         return

--- a/pydantic_encryption/integrations/sqlalchemy/bulk.py
+++ b/pydantic_encryption/integrations/sqlalchemy/bulk.py
@@ -243,6 +243,12 @@ def _on_orm_load(instance: Any, context: Any) -> None:
     bucket[type(instance)].append(instance)
 
 
+def _on_orm_refresh(instance: Any, context: Any, attrs: Any) -> None:
+    """Collect refreshed DeferredDecryptMixin instances into the session's pending bucket."""
+
+    _on_orm_load(instance, context)
+
+
 class DeferredDecryptMixin:
     """Mixin that auto-defers SQLAlchemyEncryptedValue columns and adds async decrypt helpers.
 
@@ -259,6 +265,7 @@ class DeferredDecryptMixin:
         super().__init_subclass__(**kwargs)
         event.listen(cls, "mapper_configured", _mark_encrypted_columns_deferred)
         event.listen(cls, "load", _on_orm_load)
+        event.listen(cls, "refresh", _on_orm_refresh)
 
     async def decrypt(self) -> Self:
         """Decrypt deferred encrypted columns on this instance and any loaded relationships."""

--- a/pydantic_encryption/integrations/sqlalchemy/bulk.py
+++ b/pydantic_encryption/integrations/sqlalchemy/bulk.py
@@ -6,8 +6,7 @@ from pydantic_encryption._lazy import require_optional_dependency
 
 require_optional_dependency("sqlalchemy", "sqlalchemy")
 
-from sqlalchemy import Select, event, inspect as sa_inspect
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import event, inspect as sa_inspect
 from sqlalchemy.orm.attributes import InstrumentedAttribute
 
 from pydantic_encryption.adapters.registry import get_encryption_backend
@@ -19,6 +18,31 @@ def _column_name(column: InstrumentedAttribute | str) -> str:
     if isinstance(column, str):
         return column
     return column.key
+
+
+def _build_decrypt_cell(
+    concurrency: int | None,
+    caller_name: str,
+):
+    """Build a single decrypt-one-cell coroutine factory shared by the bulk helpers."""
+
+    if settings.ENCRYPTION_METHOD is None:
+        raise ValueError(f"ENCRYPTION_METHOD must be set to use {caller_name}.")
+
+    backend = get_encryption_backend(settings.ENCRYPTION_METHOD)
+    type_helper = SQLAlchemyEncryptedValue()
+    semaphore = asyncio.Semaphore(concurrency) if concurrency is not None else None
+
+    async def decrypt_cell(ciphertext: bytes) -> Any:
+        if semaphore is not None:
+            async with semaphore:
+                plaintext = await backend.async_decrypt(ciphertext)
+        else:
+            plaintext = await backend.async_decrypt(ciphertext)
+
+        return type_helper._deserialize_value(plaintext)
+
+    return decrypt_cell
 
 
 async def async_decrypt_rows(
@@ -45,22 +69,8 @@ async def async_decrypt_rows(
     if not rows:
         return
 
-    if settings.ENCRYPTION_METHOD is None:
-        raise ValueError("ENCRYPTION_METHOD must be set to use async_decrypt_rows.")
-
-    backend = get_encryption_backend(settings.ENCRYPTION_METHOD)
-    type_helper = SQLAlchemyEncryptedValue()
+    decrypt_cell = _build_decrypt_cell(concurrency, "async_decrypt_rows")
     column_names = [_column_name(c) for c in columns]
-
-    semaphore = asyncio.Semaphore(concurrency) if concurrency is not None else None
-
-    async def decrypt_cell(ciphertext: bytes) -> Any:
-        if semaphore is not None:
-            async with semaphore:
-                plaintext = await backend.async_decrypt(ciphertext)
-        else:
-            plaintext = await backend.async_decrypt(ciphertext)
-        return type_helper._deserialize_value(plaintext)
 
     assignments: list[tuple[Any, str]] = []
     coros = []
@@ -79,6 +89,47 @@ async def async_decrypt_rows(
     results = await asyncio.gather(*coros)
     for (row, name), plaintext in zip(assignments, results):
         setattr(row, name, plaintext)
+
+
+async def async_decrypt_values(
+    values: Iterable[Any],
+    *,
+    concurrency: int | None = None,
+) -> list[Any]:
+    """Bulk-decrypt a flat iterable of ciphertexts, preserving ``None`` positions.
+
+    Returned list has the same length as ``values`` with plaintexts substituted
+    for each non-``None`` input. Any cell already holding plaintext (not
+    ``bytes``/``bytearray``) is passed through untouched, matching the read-
+    path convention used by ``async_decrypt_rows``.
+    """
+
+    values_list = list(values)
+    if not values_list:
+        return []
+
+    decrypt_cell = _build_decrypt_cell(concurrency, "async_decrypt_values")
+
+    indexed: list[tuple[int, Any]] = []
+    coros = []
+    for index, value in enumerate(values_list):
+        if value is None:
+            continue
+        if not isinstance(value, (bytes, bytearray)):
+            continue
+        ciphertext = bytes(value) if not isinstance(value, bytes) else value
+        coros.append(decrypt_cell(ciphertext))
+        indexed.append((index, value))
+
+    if not coros:
+        return values_list
+
+    results = await asyncio.gather(*coros)
+    out = list(values_list)
+    for (index, _), plaintext in zip(indexed, results):
+        out[index] = plaintext
+
+    return out
 
 
 async def _bulk_decrypt(entities: Any | Iterable[Any] | None) -> None:
@@ -172,8 +223,8 @@ class DeferredDecryptMixin:
 
     Every ``SQLAlchemyEncryptedValue`` column on a class that inherits this mixin returns
     ``EncryptedValue(bytes)`` on read instead of plaintext; call ``decrypt()`` /
-    ``decrypt_many()`` / ``scalar_one_or_none()`` / ``scalars_all()`` to decrypt in bulk.
-    ``SQLAlchemyPGEncryptedArray`` columns are not affected and still decrypt inline.
+    ``decrypt_many()`` to decrypt in bulk. ``SQLAlchemyPGEncryptedArray`` columns are not
+    affected and still decrypt inline.
     """
 
     def __init_subclass__(cls, **kwargs) -> None:
@@ -193,25 +244,5 @@ class DeferredDecryptMixin:
 
         await _bulk_decrypt(entities)
 
-    @classmethod
-    async def scalar_one_or_none(cls, session: AsyncSession, statement: Select) -> Self | None:
-        """Execute a SELECT and return a single decrypted scalar, or None."""
 
-        entity = (await session.execute(statement)).scalar_one_or_none()
-
-        await _bulk_decrypt(entity)
-
-        return entity
-
-    @classmethod
-    async def scalars_all(cls, session: AsyncSession, statement: Select) -> list[Self]:
-        """Execute a SELECT and return all decrypted scalars as a list."""
-
-        rows = list((await session.execute(statement)).scalars().all())
-
-        await _bulk_decrypt(rows)
-
-        return rows
-
-
-__all__ = ["async_decrypt_rows", "DeferredDecryptMixin"]
+__all__ = ["async_decrypt_rows", "async_decrypt_values", "DeferredDecryptMixin"]

--- a/pydantic_encryption/integrations/sqlalchemy/bulk.py
+++ b/pydantic_encryption/integrations/sqlalchemy/bulk.py
@@ -1,16 +1,17 @@
 import asyncio
-from typing import Any, Iterable
+from typing import Any, Iterable, Self
 
 from pydantic_encryption._lazy import require_optional_dependency
 
 require_optional_dependency("sqlalchemy", "sqlalchemy")
 
+from sqlalchemy import Select, inspect as sa_inspect
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm.attributes import InstrumentedAttribute
 
 from pydantic_encryption.adapters.registry import get_encryption_backend
 from pydantic_encryption.config import settings
 from pydantic_encryption.integrations.sqlalchemy.encryption import SQLAlchemyEncryptedValue
-from pydantic_encryption.types import EncryptedValue
 
 
 def _column_name(column: InstrumentedAttribute | str) -> str:
@@ -47,7 +48,6 @@ async def async_decrypt_rows(
         raise ValueError("ENCRYPTION_METHOD must be set to use async_decrypt_rows.")
 
     backend = get_encryption_backend(settings.ENCRYPTION_METHOD)
-    # Reuse a TypeDecorator instance purely for its deserialization helper.
     type_helper = SQLAlchemyEncryptedValue()
     column_names = [_column_name(c) for c in columns]
 
@@ -80,4 +80,117 @@ async def async_decrypt_rows(
         setattr(row, name, plaintext)
 
 
-__all__ = ["async_decrypt_rows"]
+async def _bulk_decrypt(entities: Any | Iterable[Any] | None) -> None:
+    """Walk entities + loaded relationships and batch-decrypt deferred encrypted cells."""
+
+    collected: dict[tuple[type, str], list[Any]] = {}
+    visited: set[int] = set()
+    _collect_encrypted_cells(entities, collected, visited)
+
+    if not collected:
+        return
+
+    awaitables = [
+        async_decrypt_rows(rows, getattr(cls, column_key))
+        for (cls, column_key), rows in collected.items()
+    ]
+
+    await asyncio.gather(*awaitables)
+
+
+def _collect_encrypted_cells(
+    entities: Any | Iterable[Any] | None,
+    collected: dict[tuple[type, str], list[Any]],
+    visited: set[int],
+) -> None:
+    """Walk entities (and loaded relationships) and group rows by (class, column) for deferred-encrypted cells."""
+
+    if entities is None:
+        return
+
+    if isinstance(entities, (list, tuple, set, frozenset)):
+        items = list(entities)
+    else:
+        items = [entities]
+
+    for entity in items:
+        if entity is None:
+            continue
+
+        entity_id = id(entity)
+        if entity_id in visited:
+            continue
+        visited.add(entity_id)
+
+        state = sa_inspect(entity, raiseerr=False)
+        if state is None or not hasattr(state, "mapper"):
+            continue
+
+        mapper = state.mapper
+
+        for column in mapper.columns:
+            if not isinstance(column.type, SQLAlchemyEncryptedValue):
+                continue
+
+            if not column.type.defer_decrypt:
+                continue
+
+            value = state.dict.get(column.key)
+            if not isinstance(value, (bytes, bytearray)):
+                continue
+
+            collected.setdefault((type(entity), column.key), []).append(entity)
+
+        unloaded = state.unloaded
+        for relationship in mapper.relationships:
+            if relationship.key in unloaded:
+                continue
+
+            related = state.dict.get(relationship.key)
+            if related is None:
+                continue
+
+            if relationship.uselist:
+                _collect_encrypted_cells(list(related), collected, visited)
+            else:
+                _collect_encrypted_cells(related, collected, visited)
+
+
+class DeferredDecryptMixin:
+    """Mixin that adds async decrypt helpers for deferred SQLAlchemyEncryptedValue columns."""
+
+    async def decrypt(self) -> Self:
+        """Decrypt deferred encrypted columns on this instance and any loaded relationships."""
+
+        await _bulk_decrypt(self)
+
+        return self
+
+    @classmethod
+    async def decrypt_many(cls, entities: Any | Iterable[Any] | None) -> None:
+        """Decrypt deferred encrypted columns on the given entities (single, iterable, or None) and any loaded relationships."""
+
+        await _bulk_decrypt(entities)
+
+    @classmethod
+    async def scalar_one_or_none(cls, session: AsyncSession, statement: Select) -> Self | None:
+        """Execute a SELECT and return a single decrypted scalar, or None."""
+
+        entity = (await session.execute(statement)).scalar_one_or_none()
+
+        await _bulk_decrypt(entity)
+
+        return entity
+
+    @classmethod
+    async def scalars_all(cls, session: AsyncSession, statement: Select) -> list[Self]:
+        """Execute a SELECT and return all decrypted scalars as a list."""
+
+        rows = list((await session.execute(statement)).scalars().all())
+
+        await _bulk_decrypt(rows)
+
+        return rows
+
+
+__all__ = ["async_decrypt_rows", "DeferredDecryptMixin"]

--- a/pydantic_encryption/integrations/sqlalchemy/bulk.py
+++ b/pydantic_encryption/integrations/sqlalchemy/bulk.py
@@ -1,4 +1,5 @@
 import asyncio
+from collections import defaultdict
 from collections.abc import Iterable
 from typing import Any, Self
 
@@ -7,11 +8,15 @@ from pydantic_encryption._lazy import require_optional_dependency
 require_optional_dependency("sqlalchemy", "sqlalchemy")
 
 from sqlalchemy import event, inspect as sa_inspect
-from sqlalchemy.orm.attributes import InstrumentedAttribute
+from sqlalchemy.orm.attributes import InstrumentedAttribute, set_committed_value
 
 from pydantic_encryption.adapters.registry import get_encryption_backend
 from pydantic_encryption.config import settings
 from pydantic_encryption.integrations.sqlalchemy.encryption import SQLAlchemyEncryptedValue
+from pydantic_encryption.types import EncryptedValue
+
+AUTO_DECRYPT_ENABLED_KEY = "__pydantic_encryption_auto_decrypt__"
+PENDING_DECRYPT_KEY = "__pydantic_encryption_pending_decrypt__"
 
 
 def _column_name(column: InstrumentedAttribute | str) -> str:
@@ -88,7 +93,17 @@ async def async_decrypt_rows(
 
     results = await asyncio.gather(*coros)
     for (row, name), plaintext in zip(assignments, results):
+        _set_decrypted(row, name, plaintext)
+
+
+def _set_decrypted(row: Any, name: str, plaintext: Any) -> None:
+    """Set a decrypted value on a row without marking the column as dirty for the next flush."""
+
+    state = sa_inspect(row, raiseerr=False)
+    if state is None or not hasattr(state, "mapper"):
         setattr(row, name, plaintext)
+        return
+    set_committed_value(row, name, plaintext)
 
 
 async def async_decrypt_values(
@@ -188,7 +203,7 @@ def _collect_encrypted_cells(
                 continue
 
             value = state.dict.get(column.key)
-            if not isinstance(value, (bytes, bytearray)):
+            if not isinstance(value, EncryptedValue):
                 continue
 
             collected.setdefault((type(entity), column.key), []).append(entity)
@@ -218,6 +233,16 @@ def _mark_encrypted_columns_deferred(mapper, class_) -> None:
         column.type._deferred = True
 
 
+def _on_orm_load(instance: Any, context: Any) -> None:
+    """Collect freshly loaded DeferredDecryptMixin instances into the session's pending bucket."""
+
+    session = context.session
+    if session is None or not session.info.get(AUTO_DECRYPT_ENABLED_KEY):
+        return
+    bucket: dict[type, list[Any]] = session.info.setdefault(PENDING_DECRYPT_KEY, defaultdict(list))
+    bucket[type(instance)].append(instance)
+
+
 class DeferredDecryptMixin:
     """Mixin that auto-defers SQLAlchemyEncryptedValue columns and adds async decrypt helpers.
 
@@ -225,11 +250,15 @@ class DeferredDecryptMixin:
     ``EncryptedValue(bytes)`` on read instead of plaintext; call ``decrypt()`` /
     ``decrypt_many()`` to decrypt in bulk. ``SQLAlchemyPGEncryptedArray`` columns are not
     affected and still decrypt inline.
+
+    When loaded through :class:`AutoDecryptAsyncSession`, instances are batch-decrypted
+    automatically after each ``execute()`` and the explicit decrypt calls are unnecessary.
     """
 
     def __init_subclass__(cls, **kwargs) -> None:
         super().__init_subclass__(**kwargs)
         event.listen(cls, "mapper_configured", _mark_encrypted_columns_deferred)
+        event.listen(cls, "load", _on_orm_load)
 
     async def decrypt(self) -> Self:
         """Decrypt deferred encrypted columns on this instance and any loaded relationships."""

--- a/pydantic_encryption/integrations/sqlalchemy/encryption.py
+++ b/pydantic_encryption/integrations/sqlalchemy/encryption.py
@@ -21,16 +21,17 @@ class SQLAlchemyEncryptedValue(TypeDecorator):
 
     Under ``AsyncSession``, decryption automatically uses SQLAlchemy's greenlet
     bridge so network-bound backends (e.g. AWS KMS) yield the event loop during
-    decryption. For true parallelism across many rows, pass ``defer_decrypt=True``
-    and use :func:`pydantic_encryption.async_decrypt_rows` post-fetch.
+    decryption. For true parallelism across many rows, inherit
+    :class:`pydantic_encryption.DeferredDecryptMixin` on the model and combine
+    with :func:`pydantic_encryption.async_decrypt_rows` post-fetch.
     """
 
     impl = LargeBinary
     cache_ok = True
 
-    def __init__(self, *args, defer_decrypt: bool = False, **kwargs) -> None:
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        self.defer_decrypt = defer_decrypt
+        self._deferred = False
 
     def _serialize_value(self, value: EncryptableValue) -> str:
         """Serialize a value with version and type prefix for encryption."""
@@ -147,7 +148,7 @@ class SQLAlchemyEncryptedValue(TypeDecorator):
         if value is None:
             return None
 
-        if self.defer_decrypt:
+        if self._deferred:
             return EncryptedValue(value) if isinstance(value, bytes) else EncryptedValue(value.encode("utf-8"))
 
         decrypted_value = self._process_decrypt_value(value)

--- a/pydantic_encryption/integrations/sqlalchemy/session.py
+++ b/pydantic_encryption/integrations/sqlalchemy/session.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from pydantic_encryption.integrations.sqlalchemy.bulk import (
     AUTO_DECRYPT_ENABLED_KEY,
     PENDING_DECRYPT_KEY,
+    _bulk_decrypt,
 )
 
 
@@ -51,13 +52,13 @@ class AutoDecryptAsyncSession(AsyncSession):
         return result
 
     async def _drain_pending_decrypt(self) -> None:
-        """Pop the per-session pending bucket and call decrypt_many per class."""
+        """Pop the per-session pending bucket and decrypt every class's cells in one gather."""
 
         pending: dict[type, list[Any]] | None = self.info.pop(PENDING_DECRYPT_KEY, None)
         if not pending:
             return
-        for cls, instances in pending.items():
-            await cls.decrypt_many(instances)
+        all_instances = [instance for instances in pending.values() for instance in instances]
+        await _bulk_decrypt(all_instances)
 
 
 __all__ = ["AutoDecryptAsyncSession"]

--- a/pydantic_encryption/integrations/sqlalchemy/session.py
+++ b/pydantic_encryption/integrations/sqlalchemy/session.py
@@ -1,0 +1,43 @@
+from typing import Any
+
+from pydantic_encryption._lazy import require_optional_dependency
+
+require_optional_dependency("sqlalchemy", "sqlalchemy")
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from pydantic_encryption.integrations.sqlalchemy.bulk import (
+    AUTO_DECRYPT_ENABLED_KEY,
+    PENDING_DECRYPT_KEY,
+)
+
+
+class AutoDecryptAsyncSession(AsyncSession):
+    """AsyncSession that batch-decrypts deferred DeferredDecryptMixin rows after each execute().
+
+    Streaming queries (``stream``, ``stream_scalars``) bypass auto-decrypt — call
+    ``Model.decrypt_many(batch)`` per chunk or materialize the result with ``.all()``.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.info[AUTO_DECRYPT_ENABLED_KEY] = True
+
+    async def execute(self, statement, *args, **kwargs):
+        """Run the query, then batch-decrypt every DeferredDecryptMixin row populated by it."""
+
+        result = await super().execute(statement, *args, **kwargs)
+        await self._drain_pending_decrypt()
+        return result
+
+    async def _drain_pending_decrypt(self) -> None:
+        """Pop the per-session pending bucket and call decrypt_many per class."""
+
+        pending: dict[type, list[Any]] | None = self.info.pop(PENDING_DECRYPT_KEY, None)
+        if not pending:
+            return
+        for cls, instances in pending.items():
+            await cls.decrypt_many(instances)
+
+
+__all__ = ["AutoDecryptAsyncSession"]

--- a/pydantic_encryption/integrations/sqlalchemy/session.py
+++ b/pydantic_encryption/integrations/sqlalchemy/session.py
@@ -13,7 +13,7 @@ from pydantic_encryption.integrations.sqlalchemy.bulk import (
 
 
 class AutoDecryptAsyncSession(AsyncSession):
-    """AsyncSession that batch-decrypts deferred DeferredDecryptMixin rows after each execute().
+    """AsyncSession that batch-decrypts deferred DeferredDecryptMixin rows after each load.
 
     Streaming queries (``stream``, ``stream_scalars``) bypass auto-decrypt — call
     ``Model.decrypt_many(batch)`` per chunk or materialize the result with ``.all()``.
@@ -27,6 +27,26 @@ class AutoDecryptAsyncSession(AsyncSession):
         """Run the query, then batch-decrypt every DeferredDecryptMixin row populated by it."""
 
         result = await super().execute(statement, *args, **kwargs)
+        await self._drain_pending_decrypt()
+        return result
+
+    async def get(self, *args, **kwargs):
+        """Load by primary key, then batch-decrypt the populated row."""
+
+        result = await super().get(*args, **kwargs)
+        await self._drain_pending_decrypt()
+        return result
+
+    async def refresh(self, *args, **kwargs) -> None:
+        """Refresh attributes from the DB, then batch-decrypt the repopulated row."""
+
+        await super().refresh(*args, **kwargs)
+        await self._drain_pending_decrypt()
+
+    async def merge(self, *args, **kwargs):
+        """Merge state into the session, then batch-decrypt any rows loaded as a side effect."""
+
+        result = await super().merge(*args, **kwargs)
         await self._drain_pending_decrypt()
         return result
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic_encryption"
-version = "0.7.0"
+version = "0.8.0"
 description = "Encryption, hashing, and blind indexing for Pydantic"
 authors = [
     { name = "Julien Kmec", email = "me@julien.dev" },

--- a/tests/unit/test_sqlalchemy/test_auto_decrypt_session.py
+++ b/tests/unit/test_sqlalchemy/test_auto_decrypt_session.py
@@ -1,0 +1,200 @@
+import asyncio
+from collections import defaultdict
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+from sqlalchemy import inspect as sa_inspect
+from sqlalchemy.orm import DeclarativeBase, Mapped, configure_mappers, mapped_column
+
+from pydantic_encryption.integrations.sqlalchemy import (
+    AutoDecryptAsyncSession,
+    DeferredDecryptMixin,
+)
+from pydantic_encryption.integrations.sqlalchemy.bulk import (
+    AUTO_DECRYPT_ENABLED_KEY,
+    PENDING_DECRYPT_KEY,
+    _collect_encrypted_cells,
+    _on_orm_load,
+)
+from pydantic_encryption.integrations.sqlalchemy.encryption import SQLAlchemyEncryptedValue
+from pydantic_encryption.types import EncryptedValue
+
+
+class _AutoDecryptBase(DeclarativeBase):
+    """Isolated declarative base for AutoDecryptAsyncSession unit tests."""
+
+
+class _AutoDecryptUser(_AutoDecryptBase, DeferredDecryptMixin):
+    """Mapped class with a string-typed deferred encrypted column."""
+
+    __tablename__ = "_auto_decrypt_user"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    email: Mapped[str | None] = mapped_column(
+        SQLAlchemyEncryptedValue(), nullable=True, default=None
+    )
+
+
+class _AutoDecryptBlob(_AutoDecryptBase, DeferredDecryptMixin):
+    """Mapped class with a bytes-typed deferred encrypted column to test idempotency."""
+
+    __tablename__ = "_auto_decrypt_blob"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    payload: Mapped[bytes | None] = mapped_column(
+        SQLAlchemyEncryptedValue(), nullable=True, default=None
+    )
+
+
+def _encrypt(value: Any) -> bytes:
+    """Encrypt a value via the SQLAlchemyEncryptedValue write path."""
+
+    return SQLAlchemyEncryptedValue().process_bind_param(value, None)
+
+
+def _wrap(value: Any) -> EncryptedValue:
+    """Wrap ciphertext in EncryptedValue the way process_result_value does on read."""
+
+    return EncryptedValue(_encrypt(value))
+
+
+class TestOnOrmLoadListener:
+    """Test that _on_orm_load collects instances only when the auto-decrypt flag is set."""
+
+    @classmethod
+    def setup_class(cls):
+        configure_mappers()
+
+    def test_collects_when_flag_enabled(self):
+        session = SimpleNamespace(info={AUTO_DECRYPT_ENABLED_KEY: True})
+        context = SimpleNamespace(session=session)
+        instance = _AutoDecryptUser(id=1)
+
+        _on_orm_load(instance, context)
+
+        bucket = session.info[PENDING_DECRYPT_KEY]
+        assert bucket[_AutoDecryptUser] == [instance]
+
+    def test_noop_when_flag_missing(self):
+        session = SimpleNamespace(info={})
+        context = SimpleNamespace(session=session)
+
+        _on_orm_load(_AutoDecryptUser(id=1), context)
+
+        assert PENDING_DECRYPT_KEY not in session.info
+
+    def test_noop_when_session_is_none(self):
+        context = SimpleNamespace(session=None)
+
+        _on_orm_load(_AutoDecryptUser(id=1), context)  # no exception
+
+    def test_groups_by_class(self):
+        session = SimpleNamespace(info={AUTO_DECRYPT_ENABLED_KEY: True})
+        context = SimpleNamespace(session=session)
+        user_a = _AutoDecryptUser(id=1)
+        user_b = _AutoDecryptUser(id=2)
+        blob = _AutoDecryptBlob(id=1)
+
+        _on_orm_load(user_a, context)
+        _on_orm_load(user_b, context)
+        _on_orm_load(blob, context)
+
+        bucket = session.info[PENDING_DECRYPT_KEY]
+        assert bucket[_AutoDecryptUser] == [user_a, user_b]
+        assert bucket[_AutoDecryptBlob] == [blob]
+
+
+class TestAutoDecryptAsyncSession:
+    """Test AutoDecryptAsyncSession init and drain behavior."""
+
+    def test_init_sets_enabled_flag(self):
+        session = AutoDecryptAsyncSession(bind=None)
+
+        assert session.info[AUTO_DECRYPT_ENABLED_KEY] is True
+
+    def test_drain_calls_decrypt_many_per_class(self):
+        session = AutoDecryptAsyncSession(bind=None)
+        user = _AutoDecryptUser(id=1, email=_wrap("a@x.com"))
+        blob = _AutoDecryptBlob(id=1, payload=_wrap(b"shh"))
+
+        bucket: dict[type, list[Any]] = defaultdict(list)
+        bucket[_AutoDecryptUser].append(user)
+        bucket[_AutoDecryptBlob].append(blob)
+        session.info[PENDING_DECRYPT_KEY] = bucket
+
+        asyncio.run(session._drain_pending_decrypt())
+
+        assert user.email == "a@x.com"
+        assert blob.payload == b"shh"
+        assert PENDING_DECRYPT_KEY not in session.info
+
+    def test_drain_noop_when_bucket_empty(self):
+        session = AutoDecryptAsyncSession(bind=None)
+
+        asyncio.run(session._drain_pending_decrypt())  # no exception
+
+        assert PENDING_DECRYPT_KEY not in session.info
+
+    def test_execute_drains_after_super_execute(self):
+        session = AutoDecryptAsyncSession(bind=None)
+        user = _AutoDecryptUser(id=1, email=_wrap("a@x.com"))
+        bucket: dict[type, list[Any]] = defaultdict(list)
+        bucket[_AutoDecryptUser].append(user)
+        session.info[PENDING_DECRYPT_KEY] = bucket
+
+        sentinel_result = object()
+
+        async def fake_super_execute(*args, **kwargs):
+            return sentinel_result
+
+        session.__class__.__bases__[0].execute = AsyncMock(side_effect=fake_super_execute)
+        try:
+            result = asyncio.run(session.execute("SELECT 1"))
+        finally:
+            del session.__class__.__bases__[0].execute
+
+        assert result is sentinel_result
+        assert user.email == "a@x.com"
+
+
+class TestBytesColumnIdempotency:
+    """Regression test: BYTES-typed columns must not double-decrypt under repeated load events."""
+
+    @classmethod
+    def setup_class(cls):
+        configure_mappers()
+
+    def test_collect_skips_already_decrypted_bytes_plaintext(self):
+        blob = _AutoDecryptBlob(id=1, payload=_wrap(b"shh"))
+
+        asyncio.run(_AutoDecryptBlob.decrypt_many([blob]))
+
+        assert blob.payload == b"shh"
+        assert not isinstance(blob.payload, EncryptedValue)
+
+        collected: dict[tuple[type, str], list[Any]] = {}
+        visited: set[int] = set()
+        _collect_encrypted_cells(blob, collected, visited)
+
+        assert collected == {}
+
+
+class TestNoDirtyAfterDecrypt:
+    """Regression test: decrypted columns must not be marked dirty for the next flush."""
+
+    @classmethod
+    def setup_class(cls):
+        configure_mappers()
+
+    def test_decrypt_many_does_not_mark_column_dirty(self):
+        user = _AutoDecryptUser(id=1, email=_wrap("a@x.com"))
+        state = sa_inspect(user)
+        state._commit_all(state.dict)
+
+        assert "email" not in state.committed_state
+
+        asyncio.run(_AutoDecryptUser.decrypt_many([user]))
+
+        assert user.email == "a@x.com"
+        assert "email" not in state.committed_state

--- a/tests/unit/test_sqlalchemy/test_auto_decrypt_session.py
+++ b/tests/unit/test_sqlalchemy/test_auto_decrypt_session.py
@@ -116,7 +116,7 @@ class TestAutoDecryptAsyncSession:
 
         assert session.info[AUTO_DECRYPT_ENABLED_KEY] is True
 
-    def test_drain_calls_decrypt_many_per_class(self):
+    def test_drain_decrypts_every_pending_class(self):
         session = AutoDecryptAsyncSession(bind=None)
         user = _AutoDecryptUser(id=1, email=_wrap("a@x.com"))
         blob = _AutoDecryptBlob(id=1, payload=_wrap(b"shh"))
@@ -237,6 +237,45 @@ class TestBytesColumnIdempotency:
         _collect_encrypted_cells(blob, collected, visited)
 
         assert collected == {}
+
+
+class TestDrainParallelism:
+    """Regression test: the drain must fan out every class's cells in a single gather."""
+
+    @classmethod
+    def setup_class(cls):
+        configure_mappers()
+
+    def test_drain_gathers_cells_across_classes_in_parallel(self):
+        session = AutoDecryptAsyncSession(bind=None)
+        user = _AutoDecryptUser(id=1, email=_wrap("a@x.com"))
+        blob = _AutoDecryptBlob(id=1, payload=_wrap(b"shh"))
+
+        bucket: dict[type, list[Any]] = defaultdict(list)
+        bucket[_AutoDecryptUser].append(user)
+        bucket[_AutoDecryptBlob].append(blob)
+        session.info[PENDING_DECRYPT_KEY] = bucket
+
+        gather_calls: list[int] = []
+        original_gather = asyncio.gather
+
+        async def counting_gather(*coros, **kwargs):
+            gather_calls.append(len(coros))
+            return await original_gather(*coros, **kwargs)
+
+        asyncio.gather = counting_gather  # type: ignore[assignment]
+        try:
+            asyncio.run(session._drain_pending_decrypt())
+        finally:
+            asyncio.gather = original_gather  # type: ignore[assignment]
+
+        assert user.email == "a@x.com"
+        assert blob.payload == b"shh"
+        assert gather_calls, "expected asyncio.gather to be invoked by the drain"
+        assert max(gather_calls) >= 2, (
+            "expected at least one gather to span both classes' cells; "
+            f"got gather widths {gather_calls}"
+        )
 
 
 class TestNoDirtyAfterDecrypt:

--- a/tests/unit/test_sqlalchemy/test_auto_decrypt_session.py
+++ b/tests/unit/test_sqlalchemy/test_auto_decrypt_session.py
@@ -157,6 +157,62 @@ class TestAutoDecryptAsyncSession:
         assert result is sentinel_result
         assert user.email == "a@x.com"
 
+    def test_get_drains_after_super_get(self):
+        session = AutoDecryptAsyncSession(bind=None)
+        user = _AutoDecryptUser(id=1, email=_wrap("a@x.com"))
+        bucket: dict[type, list[Any]] = defaultdict(list)
+        bucket[_AutoDecryptUser].append(user)
+        session.info[PENDING_DECRYPT_KEY] = bucket
+
+        async def fake_super_get(*args, **kwargs):
+            return user
+
+        session.__class__.__bases__[0].get = AsyncMock(side_effect=fake_super_get)
+        try:
+            result = asyncio.run(session.get(_AutoDecryptUser, 1))
+        finally:
+            del session.__class__.__bases__[0].get
+
+        assert result is user
+        assert user.email == "a@x.com"
+
+    def test_refresh_drains_after_super_refresh(self):
+        session = AutoDecryptAsyncSession(bind=None)
+        user = _AutoDecryptUser(id=1, email=_wrap("a@x.com"))
+        bucket: dict[type, list[Any]] = defaultdict(list)
+        bucket[_AutoDecryptUser].append(user)
+        session.info[PENDING_DECRYPT_KEY] = bucket
+
+        async def fake_super_refresh(*args, **kwargs):
+            return None
+
+        session.__class__.__bases__[0].refresh = AsyncMock(side_effect=fake_super_refresh)
+        try:
+            asyncio.run(session.refresh(user))
+        finally:
+            del session.__class__.__bases__[0].refresh
+
+        assert user.email == "a@x.com"
+
+    def test_merge_drains_after_super_merge(self):
+        session = AutoDecryptAsyncSession(bind=None)
+        user = _AutoDecryptUser(id=1, email=_wrap("a@x.com"))
+        bucket: dict[type, list[Any]] = defaultdict(list)
+        bucket[_AutoDecryptUser].append(user)
+        session.info[PENDING_DECRYPT_KEY] = bucket
+
+        async def fake_super_merge(*args, **kwargs):
+            return user
+
+        session.__class__.__bases__[0].merge = AsyncMock(side_effect=fake_super_merge)
+        try:
+            result = asyncio.run(session.merge(user))
+        finally:
+            del session.__class__.__bases__[0].merge
+
+        assert result is user
+        assert user.email == "a@x.com"
+
 
 class TestBytesColumnIdempotency:
     """Regression test: BYTES-typed columns must not double-decrypt under repeated load events."""

--- a/tests/unit/test_sqlalchemy/test_auto_decrypt_session.py
+++ b/tests/unit/test_sqlalchemy/test_auto_decrypt_session.py
@@ -89,6 +89,9 @@ class TestOnOrmLoadListener:
 
         _on_orm_load(_AutoDecryptUser(id=1), context)  # no exception
 
+    def test_noop_when_context_is_none(self):
+        _on_orm_load(_AutoDecryptUser(id=1), None)  # no exception
+
     def test_groups_by_class(self):
         session = SimpleNamespace(info={AUTO_DECRYPT_ENABLED_KEY: True})
         context = SimpleNamespace(session=session)

--- a/tests/unit/test_sqlalchemy/test_bulk.py
+++ b/tests/unit/test_sqlalchemy/test_bulk.py
@@ -191,6 +191,22 @@ class TestDeferredDecryptMixin:
             assert contractor.first_name == f"First{i}"
             assert contractor.last_name == f"Last{i}"
 
+    def test_decrypt_many_accepts_generator(self):
+        contractors = [
+            _BulkContractor(
+                id=i,
+                first_name=_encrypt_deferred(f"Gen{i}"),
+                last_name=_encrypt_deferred(f"Last{i}"),
+            )
+            for i in range(3)
+        ]
+
+        asyncio.run(_BulkContractor.decrypt_many(c for c in contractors))
+
+        for i, contractor in enumerate(contractors):
+            assert contractor.first_name == f"Gen{i}"
+            assert contractor.last_name == f"Last{i}"
+
     def test_none_column_values_skipped(self):
         contractor = _BulkContractor(id=1, first_name=_encrypt_deferred("Alice"), last_name=None)
 

--- a/tests/unit/test_sqlalchemy/test_bulk.py
+++ b/tests/unit/test_sqlalchemy/test_bulk.py
@@ -1,9 +1,12 @@
 import asyncio
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
+from sqlalchemy import ForeignKey
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
-from pydantic_encryption.integrations.sqlalchemy import async_decrypt_rows
+from pydantic_encryption.integrations.sqlalchemy import DeferredDecryptMixin, async_decrypt_rows
 from pydantic_encryption.integrations.sqlalchemy.encryption import SQLAlchemyEncryptedValue
 from pydantic_encryption.types import EncryptedValue
 
@@ -81,3 +84,171 @@ class TestAsyncDecryptRows:
 
         for i, row in enumerate(rows):
             assert row.email == f"u{i}@x.com"
+
+
+class _BulkBase(DeclarativeBase):
+    """Isolated declarative base for DeferredDecryptMixin tests."""
+
+
+class _BulkOrg(_BulkBase, DeferredDecryptMixin):
+    """Test ORM parent with no encrypted columns."""
+
+    __tablename__ = "_bulk_test_org"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str | None] = mapped_column(nullable=True, default=None)
+    contractors: Mapped[list["_BulkContractor"]] = relationship(back_populates="org")
+
+
+class _BulkContractor(_BulkBase, DeferredDecryptMixin):
+    """Test ORM child with deferred encrypted columns."""
+
+    __tablename__ = "_bulk_test_contractor"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    org_id: Mapped[int | None] = mapped_column(ForeignKey("_bulk_test_org.id"), nullable=True, default=None)
+    first_name: Mapped[str | None] = mapped_column(
+        SQLAlchemyEncryptedValue(defer_decrypt=True), nullable=True, default=None
+    )
+    last_name: Mapped[str | None] = mapped_column(
+        SQLAlchemyEncryptedValue(defer_decrypt=True), nullable=True, default=None
+    )
+    org: Mapped["_BulkOrg | None"] = relationship(back_populates="contractors")
+
+
+def _encrypt_deferred(value: str) -> bytes:
+    """Encrypt a value using the non-deferred SQLAlchemyEncryptedValue on the write path."""
+
+    return SQLAlchemyEncryptedValue(defer_decrypt=False).process_bind_param(value, None)
+
+
+class TestDeferredDecryptMixin:
+    """Test the DeferredDecryptMixin decrypt() and decrypt_many() helpers."""
+
+    def test_decrypt_many_none_and_empty(self):
+        asyncio.run(_BulkContractor.decrypt_many(None))
+        asyncio.run(_BulkContractor.decrypt_many([]))
+
+    def test_instance_decrypt(self):
+        contractor = _BulkContractor(
+            id=1,
+            first_name=_encrypt_deferred("Alice"),
+            last_name=_encrypt_deferred("Smith"),
+        )
+
+        returned = asyncio.run(contractor.decrypt())
+
+        assert returned is contractor
+        assert contractor.first_name == "Alice"
+        assert contractor.last_name == "Smith"
+
+    def test_decrypt_many(self):
+        contractors = [
+            _BulkContractor(
+                id=i,
+                first_name=_encrypt_deferred(f"First{i}"),
+                last_name=_encrypt_deferred(f"Last{i}"),
+            )
+            for i in range(3)
+        ]
+
+        asyncio.run(_BulkContractor.decrypt_many(contractors))
+
+        for i, contractor in enumerate(contractors):
+            assert contractor.first_name == f"First{i}"
+            assert contractor.last_name == f"Last{i}"
+
+    def test_none_column_values_skipped(self):
+        contractor = _BulkContractor(id=1, first_name=_encrypt_deferred("Alice"), last_name=None)
+
+        asyncio.run(contractor.decrypt())
+
+        assert contractor.first_name == "Alice"
+        assert contractor.last_name is None
+
+    def test_walks_loaded_relationships(self):
+        org = _BulkOrg(id=1, name="Acme")
+        contractor = _BulkContractor(id=1, first_name=_encrypt_deferred("Alice"), last_name=None)
+        org.contractors = [contractor]
+
+        asyncio.run(org.decrypt())
+
+        assert contractor.first_name == "Alice"
+
+    def test_all_columns_none(self):
+        contractor = _BulkContractor(id=1, first_name=None, last_name=None)
+
+        asyncio.run(contractor.decrypt())
+
+        assert contractor.first_name is None
+        assert contractor.last_name is None
+
+
+class TestDeferredDecryptScalarHelpers:
+    """Test the scalar_one_or_none and scalars_all query helpers on DeferredDecryptMixin."""
+
+    def _make_session_stub(self, returned: Any) -> Any:
+        """Return a minimal async session stub whose execute() returns a fake Result."""
+
+        class _Result:
+            def __init__(self, value):
+                self._value = value
+
+            def scalar_one_or_none(self):
+                return self._value if not isinstance(self._value, list) else None
+
+            def scalars(self):
+                rows = self._value if isinstance(self._value, list) else []
+
+                class _Scalars:
+                    def __init__(self, rows):
+                        self._rows = rows
+
+                    def all(self):
+                        return list(self._rows)
+
+                return _Scalars(rows)
+
+        class _Session:
+            def __init__(self, value):
+                self._value = value
+
+            async def execute(self, _stmt):
+                return _Result(self._value)
+
+        return _Session(returned)
+
+    def test_scalar_one_or_none_decrypts(self):
+        contractor = _BulkContractor(id=1, first_name=_encrypt_deferred("Alice"))
+        session = self._make_session_stub(contractor)
+
+        result = asyncio.run(_BulkContractor.scalar_one_or_none(session, object()))
+
+        assert result is contractor
+        assert contractor.first_name == "Alice"
+
+    def test_scalar_one_or_none_handles_missing(self):
+        session = self._make_session_stub(None)
+
+        result = asyncio.run(_BulkContractor.scalar_one_or_none(session, object()))
+
+        assert result is None
+
+    def test_scalars_all_decrypts(self):
+        contractors = [
+            _BulkContractor(id=i, first_name=_encrypt_deferred(f"First{i}")) for i in range(3)
+        ]
+        session = self._make_session_stub(contractors)
+
+        result = asyncio.run(_BulkContractor.scalars_all(session, object()))
+
+        assert result == contractors
+        for i, c in enumerate(result):
+            assert c.first_name == f"First{i}"
+
+    def test_scalars_all_empty(self):
+        session = self._make_session_stub([])
+
+        result = asyncio.run(_BulkContractor.scalars_all(session, object()))
+
+        assert result == []

--- a/tests/unit/test_sqlalchemy/test_bulk.py
+++ b/tests/unit/test_sqlalchemy/test_bulk.py
@@ -4,34 +4,67 @@ from typing import Any
 
 import pytest
 from sqlalchemy import ForeignKey
-from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+from sqlalchemy.orm import DeclarativeBase, Mapped, configure_mappers, mapped_column, relationship
 
 from pydantic_encryption.integrations.sqlalchemy import DeferredDecryptMixin, async_decrypt_rows
 from pydantic_encryption.integrations.sqlalchemy.encryption import SQLAlchemyEncryptedValue
 from pydantic_encryption.types import EncryptedValue
 
 
-class TestDeferDecrypt:
-    """Test that defer_decrypt=True skips decryption on the read path."""
+class _DeferBase(DeclarativeBase):
+    """Isolated declarative base for mixin auto-defer tests."""
 
-    def test_defer_decrypt_returns_encrypted_value(self):
-        adapter = SQLAlchemyEncryptedValue(defer_decrypt=True)
-        ciphertext = adapter.process_bind_param("hello", None)
+
+class _DeferMixed(_DeferBase, DeferredDecryptMixin):
+    """Mapped class that inherits DeferredDecryptMixin."""
+
+    __tablename__ = "_defer_mixed"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    secret: Mapped[str | None] = mapped_column(
+        SQLAlchemyEncryptedValue(), nullable=True, default=None
+    )
+
+
+class _DeferPlain(_DeferBase):
+    """Mapped class that does NOT inherit DeferredDecryptMixin."""
+
+    __tablename__ = "_defer_plain"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    secret: Mapped[str | None] = mapped_column(
+        SQLAlchemyEncryptedValue(), nullable=True, default=None
+    )
+
+
+class TestDeferDecrypt:
+    """Test that DeferredDecryptMixin auto-defers encrypted columns on the read path."""
+
+    @classmethod
+    def setup_class(cls):
+        configure_mappers()
+
+    def test_mixin_column_returns_encrypted_value(self):
+        column_type = _DeferMixed.__table__.c.secret.type
+        assert column_type._deferred is True
+
+        ciphertext = column_type.process_bind_param("hello", None)
         assert ciphertext is not None
 
-        result = adapter.process_result_value(ciphertext, None)
+        result = column_type.process_result_value(ciphertext, None)
         assert isinstance(result, EncryptedValue)
-        # defer_decrypt must NOT return plaintext
         assert result != "hello"
 
-    def test_defer_decrypt_none_passthrough(self):
-        adapter = SQLAlchemyEncryptedValue(defer_decrypt=True)
-        assert adapter.process_result_value(None, None) is None
+    def test_mixin_column_none_passthrough(self):
+        column_type = _DeferMixed.__table__.c.secret.type
+        assert column_type.process_result_value(None, None) is None
 
-    def test_default_decrypt_returns_plaintext(self):
-        adapter = SQLAlchemyEncryptedValue()
-        ciphertext = adapter.process_bind_param("hello", None)
-        result = adapter.process_result_value(ciphertext, None)
+    def test_plain_column_returns_plaintext(self):
+        column_type = _DeferPlain.__table__.c.secret.type
+        assert column_type._deferred is False
+
+        ciphertext = column_type.process_bind_param("hello", None)
+        result = column_type.process_result_value(ciphertext, None)
         assert result == "hello"
 
 
@@ -39,7 +72,7 @@ class TestAsyncDecryptRows:
     """Test the async_decrypt_rows bulk helper."""
 
     def _make_ciphertext(self, value):
-        return SQLAlchemyEncryptedValue(defer_decrypt=False).process_bind_param(value, None)
+        return SQLAlchemyEncryptedValue().process_bind_param(value, None)
 
     def test_async_decrypt_rows_fernet(self):
         # Build 3 fake rows with 2 encrypted columns each.
@@ -108,18 +141,18 @@ class _BulkContractor(_BulkBase, DeferredDecryptMixin):
     id: Mapped[int] = mapped_column(primary_key=True)
     org_id: Mapped[int | None] = mapped_column(ForeignKey("_bulk_test_org.id"), nullable=True, default=None)
     first_name: Mapped[str | None] = mapped_column(
-        SQLAlchemyEncryptedValue(defer_decrypt=True), nullable=True, default=None
+        SQLAlchemyEncryptedValue(), nullable=True, default=None
     )
     last_name: Mapped[str | None] = mapped_column(
-        SQLAlchemyEncryptedValue(defer_decrypt=True), nullable=True, default=None
+        SQLAlchemyEncryptedValue(), nullable=True, default=None
     )
     org: Mapped["_BulkOrg | None"] = relationship(back_populates="contractors")
 
 
 def _encrypt_deferred(value: str) -> bytes:
-    """Encrypt a value using the non-deferred SQLAlchemyEncryptedValue on the write path."""
+    """Encrypt a value using SQLAlchemyEncryptedValue on the write path."""
 
-    return SQLAlchemyEncryptedValue(defer_decrypt=False).process_bind_param(value, None)
+    return SQLAlchemyEncryptedValue().process_bind_param(value, None)
 
 
 class TestDeferredDecryptMixin:

--- a/tests/unit/test_sqlalchemy/test_bulk.py
+++ b/tests/unit/test_sqlalchemy/test_bulk.py
@@ -1,12 +1,14 @@
 import asyncio
 from types import SimpleNamespace
-from typing import Any
 
-import pytest
 from sqlalchemy import ForeignKey
 from sqlalchemy.orm import DeclarativeBase, Mapped, configure_mappers, mapped_column, relationship
 
-from pydantic_encryption.integrations.sqlalchemy import DeferredDecryptMixin, async_decrypt_rows
+from pydantic_encryption.integrations.sqlalchemy import (
+    DeferredDecryptMixin,
+    async_decrypt_rows,
+    async_decrypt_values,
+)
 from pydantic_encryption.integrations.sqlalchemy.encryption import SQLAlchemyEncryptedValue
 from pydantic_encryption.types import EncryptedValue
 
@@ -233,71 +235,44 @@ class TestDeferredDecryptMixin:
         assert contractor.last_name is None
 
 
-class TestDeferredDecryptScalarHelpers:
-    """Test the scalar_one_or_none and scalars_all query helpers on DeferredDecryptMixin."""
+class TestAsyncDecryptValues:
+    """Test the async_decrypt_values bulk helper for flat ciphertext iterables."""
 
-    def _make_session_stub(self, returned: Any) -> Any:
-        """Return a minimal async session stub whose execute() returns a fake Result."""
+    def _make_ciphertext(self, value: str) -> bytes:
+        return SQLAlchemyEncryptedValue().process_bind_param(value, None)
 
-        class _Result:
-            def __init__(self, value):
-                self._value = value
+    def test_decrypts_list_of_ciphertexts(self):
+        values = [self._make_ciphertext(f"user-{i}") for i in range(3)]
 
-            def scalar_one_or_none(self):
-                return self._value if not isinstance(self._value, list) else None
+        result = asyncio.run(async_decrypt_values(values))
 
-            def scalars(self):
-                rows = self._value if isinstance(self._value, list) else []
+        assert result == ["user-0", "user-1", "user-2"]
 
-                class _Scalars:
-                    def __init__(self, rows):
-                        self._rows = rows
-
-                    def all(self):
-                        return list(self._rows)
-
-                return _Scalars(rows)
-
-        class _Session:
-            def __init__(self, value):
-                self._value = value
-
-            async def execute(self, _stmt):
-                return _Result(self._value)
-
-        return _Session(returned)
-
-    def test_scalar_one_or_none_decrypts(self):
-        contractor = _BulkContractor(id=1, first_name=_encrypt_deferred("Alice"))
-        session = self._make_session_stub(contractor)
-
-        result = asyncio.run(_BulkContractor.scalar_one_or_none(session, object()))
-
-        assert result is contractor
-        assert contractor.first_name == "Alice"
-
-    def test_scalar_one_or_none_handles_missing(self):
-        session = self._make_session_stub(None)
-
-        result = asyncio.run(_BulkContractor.scalar_one_or_none(session, object()))
-
-        assert result is None
-
-    def test_scalars_all_decrypts(self):
-        contractors = [
-            _BulkContractor(id=i, first_name=_encrypt_deferred(f"First{i}")) for i in range(3)
+    def test_preserves_none_positions(self):
+        values = [
+            self._make_ciphertext("a"),
+            None,
+            self._make_ciphertext("b"),
+            None,
         ]
-        session = self._make_session_stub(contractors)
 
-        result = asyncio.run(_BulkContractor.scalars_all(session, object()))
+        result = asyncio.run(async_decrypt_values(values))
 
-        assert result == contractors
-        for i, c in enumerate(result):
-            assert c.first_name == f"First{i}"
+        assert result == ["a", None, "b", None]
 
-    def test_scalars_all_empty(self):
-        session = self._make_session_stub([])
+    def test_empty_input(self):
+        assert asyncio.run(async_decrypt_values([])) == []
 
-        result = asyncio.run(_BulkContractor.scalars_all(session, object()))
+    def test_passes_through_non_bytes_cells(self):
+        values = [self._make_ciphertext("a"), 42, "plain", None]
 
-        assert result == []
+        result = asyncio.run(async_decrypt_values(values))
+
+        assert result == ["a", 42, "plain", None]
+
+    def test_respects_concurrency(self):
+        values = [self._make_ciphertext(f"v{i}") for i in range(5)]
+
+        result = asyncio.run(async_decrypt_values(values, concurrency=2))
+
+        assert result == [f"v{i}" for i in range(5)]


### PR DESCRIPTION
Provides `async def decrypt()` (instance) and `decrypt_many(entities)` (classmethod)
on ORM models that inherit DeferredDecryptMixin. Both walk loaded relationships
and batch decrypt deferred SQLAlchemyEncryptedValue columns via a single
asyncio.gather, replacing the ad-hoc decrypt helper that was living in the
downstream app.

https://claude.ai/code/session_01XdtPtD3mwY3eEnsSu1iSB4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SQLAlchemy ORM load/decrypt behavior and session execution flow; mistakes could cause incorrect decryption, missed decrypts, or unintended persistence/dirty-state issues despite added regression tests.
> 
> **Overview**
> Adds **opt-in deferred decryption for SQLAlchemy ORM models** via `DeferredDecryptMixin`, which auto-marks `SQLAlchemyEncryptedValue` columns as deferred (returning `EncryptedValue`) and provides `decrypt()` / `decrypt_many()` helpers that walk loaded relationships and batch-decrypt via `asyncio.gather`.
> 
> Introduces `AutoDecryptAsyncSession`, which hooks into `execute`/`get`/`refresh`/`merge` to automatically drain and decrypt newly loaded `DeferredDecryptMixin` instances after each DB operation. Bulk utilities are refactored/expanded (`async_decrypt_rows` now avoids dirtying ORM state; new `async_decrypt_values`), docs are updated to reflect the new API, and the package version is bumped to `0.8.0` with new unit/regression tests covering idempotency, parallelism, and non-dirty flush behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e94becb3f2e2d389091e129baacd9c4e3b55e0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->