### PR TITLE
refactor: dedup encoding, backend resolution, and row scanning

### DIFF
--- a/pydantic_encryption/adapters/base.py
+++ b/pydantic_encryption/adapters/base.py
@@ -4,6 +4,12 @@ from abc import ABC, abstractmethod
 from pydantic_encryption.types import BlindIndexValue, EncryptedValue, HashedValue
 
 
+def encode_text(value: str | bytes) -> bytes:
+    """Return UTF-8 bytes for a ``str``, or the bytes unchanged."""
+
+    return value.encode("utf-8") if isinstance(value, str) else value
+
+
 class EncryptionAdapter(ABC):
     """Abstract base class for encryption adapters."""
 

--- a/pydantic_encryption/adapters/blind_index/argon2.py
+++ b/pydantic_encryption/adapters/blind_index/argon2.py
@@ -3,7 +3,7 @@ import hashlib
 from argon2.low_level import Type as Argon2Type
 from argon2.low_level import hash_secret_raw
 
-from pydantic_encryption.adapters.base import BlindIndexAdapter
+from pydantic_encryption.adapters.base import BlindIndexAdapter, encode_text
 from pydantic_encryption.adapters.registry import register_blind_index_backend
 from pydantic_encryption.types import BlindIndexMethod, BlindIndexValue
 
@@ -18,12 +18,9 @@ class Argon2BlindIndexAdapter(BlindIndexAdapter):
         if isinstance(value, BlindIndexValue):
             return value
 
-        if isinstance(value, str):
-            value = value.encode("utf-8")
-
         salt = hashlib.sha256(key).digest()[:16]
         digest = hash_secret_raw(
-            secret=value,
+            secret=encode_text(value),
             salt=salt,
             time_cost=3,
             memory_cost=65536,

--- a/pydantic_encryption/adapters/blind_index/hmac_sha256.py
+++ b/pydantic_encryption/adapters/blind_index/hmac_sha256.py
@@ -1,7 +1,7 @@
 import hashlib
 import hmac
 
-from pydantic_encryption.adapters.base import BlindIndexAdapter
+from pydantic_encryption.adapters.base import BlindIndexAdapter, encode_text
 from pydantic_encryption.adapters.registry import register_blind_index_backend
 from pydantic_encryption.types import BlindIndexMethod, BlindIndexValue
 
@@ -16,10 +16,7 @@ class HMACSHA256Adapter(BlindIndexAdapter):
         if isinstance(value, BlindIndexValue):
             return value
 
-        if isinstance(value, str):
-            value = value.encode("utf-8")
-
-        digest = hmac.new(key, value, hashlib.sha256).digest()
+        digest = hmac.new(key, encode_text(value), hashlib.sha256).digest()
 
         return BlindIndexValue(digest)
 

--- a/pydantic_encryption/adapters/encryption/aws.py
+++ b/pydantic_encryption/adapters/encryption/aws.py
@@ -12,7 +12,7 @@ import aioboto3
 import boto3
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
-from pydantic_encryption.adapters.base import EncryptionAdapter
+from pydantic_encryption.adapters.base import EncryptionAdapter, encode_text
 from pydantic_encryption.config import settings
 from pydantic_encryption.types import EncryptedValue
 
@@ -179,12 +179,10 @@ class AWSAdapter(EncryptionAdapter):
     def encrypt(cls, plaintext: bytes | str | EncryptedValue, *, key: str | None = None) -> EncryptedValue:
         if isinstance(plaintext, EncryptedValue):
             return plaintext
-        if isinstance(plaintext, str):
-            plaintext = plaintext.encode("utf-8")
 
         response = cls._sync_kms().generate_data_key(KeyId=cls._encrypt_arn(), KeySpec=DATA_KEY_SPEC)
 
-        return _seal(response["Plaintext"], response["CiphertextBlob"], plaintext)
+        return _seal(response["Plaintext"], response["CiphertextBlob"], encode_text(plaintext))
 
     @classmethod
     async def async_encrypt(
@@ -192,13 +190,11 @@ class AWSAdapter(EncryptionAdapter):
     ) -> EncryptedValue:
         if isinstance(plaintext, EncryptedValue):
             return plaintext
-        if isinstance(plaintext, str):
-            plaintext = plaintext.encode("utf-8")
 
         kms = await cls._async_kms()
         response = await kms.generate_data_key(KeyId=cls._encrypt_arn(), KeySpec=DATA_KEY_SPEC)
 
-        return _seal(response["Plaintext"], response["CiphertextBlob"], plaintext)
+        return _seal(response["Plaintext"], response["CiphertextBlob"], encode_text(plaintext))
 
     @classmethod
     def decrypt(cls, ciphertext: bytes | str | EncryptedValue, *, key: str | None = None) -> str:

--- a/pydantic_encryption/adapters/encryption/fernet.py
+++ b/pydantic_encryption/adapters/encryption/fernet.py
@@ -2,7 +2,7 @@ from typing import ClassVar
 
 from cryptography.fernet import Fernet
 
-from pydantic_encryption.adapters.base import EncryptionAdapter
+from pydantic_encryption.adapters.base import EncryptionAdapter, encode_text
 from pydantic_encryption.adapters.registry import register_encryption_backend
 from pydantic_encryption.config import settings
 from pydantic_encryption.types import EncryptedValue, EncryptionMethod
@@ -30,22 +30,13 @@ class FernetAdapter(EncryptionAdapter):
         if isinstance(plaintext, EncryptedValue):
             return plaintext
 
-        if isinstance(plaintext, str):
-            plaintext = plaintext.encode("utf-8")
-
         client = cls._get_client(key)
-        return EncryptedValue(client.encrypt(plaintext))
+        return EncryptedValue(client.encrypt(encode_text(plaintext)))
 
     @classmethod
     def decrypt(cls, ciphertext: str | bytes | EncryptedValue, *, key: str | None = None) -> str:
-        if isinstance(ciphertext, str):
-            ciphertext_bytes = ciphertext.encode("utf-8")
-        else:
-            ciphertext_bytes = ciphertext
-
         client = cls._get_client(key)
-        decrypted_bytes = client.decrypt(ciphertext_bytes)
-        return decrypted_bytes.decode("utf-8")
+        return client.decrypt(encode_text(ciphertext)).decode("utf-8")
 
 
 register_encryption_backend(EncryptionMethod.FERNET, FernetAdapter)

--- a/pydantic_encryption/integrations/sqlalchemy/blind_index.py
+++ b/pydantic_encryption/integrations/sqlalchemy/blind_index.py
@@ -76,8 +76,8 @@ class SQLAlchemyBlindIndexValue(TypeDecorator):
             backend.async_compute_blind_index, backend.compute_blind_index, value, key
         )
 
-    def process_bind_param(self, value: str | bytes | BlindIndexValue | None, dialect) -> bytes | None:
-        """Compute the blind index before binding to the database."""
+    def _process(self, value: str | bytes | BlindIndexValue | None) -> bytes | None:
+        """Compute the blind index, passing ``None`` and pre-indexed values through."""
 
         if value is None:
             return None
@@ -86,17 +86,16 @@ class SQLAlchemyBlindIndexValue(TypeDecorator):
             return value
 
         return self._compute_blind_index(value)
+
+    def process_bind_param(self, value: str | bytes | BlindIndexValue | None, dialect) -> bytes | None:
+        """Compute the blind index before binding to the database."""
+
+        return self._process(value)
 
     def process_literal_param(self, value: str | bytes | BlindIndexValue | None, dialect) -> bytes | None:
         """Compute the blind index for literal SQL expressions."""
 
-        if value is None:
-            return None
-
-        if isinstance(value, BlindIndexValue):
-            return value
-
-        return self._compute_blind_index(value)
+        return self._process(value)
 
     def process_result_value(self, value: bytes | None, dialect) -> BlindIndexValue | None:
         """Return the stored blind index wrapped as a ``BlindIndexValue``."""

--- a/pydantic_encryption/integrations/sqlalchemy/bulk.py
+++ b/pydantic_encryption/integrations/sqlalchemy/bulk.py
@@ -42,6 +42,22 @@ def _resolve_backend() -> Any:
     return get_encryption_backend(method)
 
 
+def _collect_row_assignments(
+    rows: Iterable[Any], column_keys: Iterable[str]
+) -> list[tuple[Any, str, bytes]]:
+    """Build ``(row, key, ciphertext)`` triples for every encrypted cell across rows."""
+
+    column_keys = list(column_keys)
+    assignments: list[tuple[Any, str, bytes]] = []
+    for row in rows:
+        for key in column_keys:
+            value = read_raw_cell(row, key)
+            if isinstance(value, EncryptedValue):
+                assignments.append((row, key, bytes(value)))
+
+    return assignments
+
+
 async def _decrypt_assignments(
     backend: Any, assignments: list[tuple[Any, str, bytes]]
 ) -> None:
@@ -73,13 +89,7 @@ async def decrypt_rows(rows: Iterable[Any], *columns: InstrumentedAttribute | st
         return
 
     backend = _resolve_backend()
-    column_keys = [_column_key(c) for c in columns]
-    assignments: list[tuple[Any, str, bytes]] = []
-    for row in rows:
-        for key in column_keys:
-            value = read_raw_cell(row, key)
-            if isinstance(value, EncryptedValue):
-                assignments.append((row, key, bytes(value)))
+    assignments = _collect_row_assignments(rows, (_column_key(c) for c in columns))
 
     await _decrypt_assignments(backend, assignments)
 
@@ -91,12 +101,8 @@ def decrypt_rows_sync(rows: Iterable[Any], *columns: InstrumentedAttribute | str
         return
 
     backend = _resolve_backend()
-    column_keys = [_column_key(c) for c in columns]
-    for row in rows:
-        for key in column_keys:
-            value = read_raw_cell(row, key)
-            if isinstance(value, EncryptedValue):
-                set_decrypted(row, key, decode_value(backend.decrypt(bytes(value))))
+    for row, key, ciphertext in _collect_row_assignments(rows, (_column_key(c) for c in columns)):
+        set_decrypted(row, key, decode_value(backend.decrypt(ciphertext)))
 
 
 async def decrypt_values(values: Iterable[Any]) -> list[Any]:
@@ -186,10 +192,7 @@ async def bulk_decrypt_entities(entities: Any | Iterable[Any] | None) -> None:
     backend = _resolve_backend()
     assignments: list[tuple[Any, str, bytes]] = []
     for (_, column_key), rows in collected.items():
-        for row in rows:
-            value = read_raw_cell(row, column_key)
-            if isinstance(value, EncryptedValue):
-                assignments.append((row, column_key, bytes(value)))
+        assignments.extend(_collect_row_assignments(rows, (column_key,)))
 
     await _decrypt_assignments(backend, assignments)
 

--- a/pydantic_encryption/integrations/sqlalchemy/descriptor.py
+++ b/pydantic_encryption/integrations/sqlalchemy/descriptor.py
@@ -4,14 +4,9 @@ from pydantic_encryption.lazy import require_optional_dependency
 
 require_optional_dependency("sqlalchemy", "sqlalchemy")
 
-try:
-    from sqlalchemy.util import await_  # type: ignore[attr-defined]
-except ImportError:
-    from sqlalchemy.util import await_only as await_
-
-from sqlalchemy.exc import MissingGreenlet
 from sqlalchemy.orm import object_session
 
+from pydantic_encryption.integrations.sqlalchemy.async_bridge import run_async_or_sync
 from pydantic_encryption.integrations.sqlalchemy.state import pending_siblings
 from pydantic_encryption.integrations.sqlalchemy.bulk import decrypt_rows, decrypt_rows_sync
 from pydantic_encryption.types import EncryptedValue
@@ -47,13 +42,7 @@ class DecryptOnAccessDescriptor:
         else:
             rows = {instance, *pending_siblings(session, self._cls)}
 
-        coro = decrypt_rows(rows, self._column_key)
-        try:
-            await_(coro)
-        except MissingGreenlet:
-            coro.close()
-
-            decrypt_rows_sync(rows, self._column_key)
+        run_async_or_sync(decrypt_rows, decrypt_rows_sync, rows, self._column_key)
 
         return self._wrapped.__get__(instance, owner)
 

--- a/pydantic_encryption/integrations/sqlalchemy/encryption.py
+++ b/pydantic_encryption/integrations/sqlalchemy/encryption.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from pydantic_encryption.lazy import require_optional_dependency
 
 require_optional_dependency("sqlalchemy", "sqlalchemy")
@@ -25,6 +27,15 @@ class SQLAlchemyEncryptedValue(TypeDecorator):
         super().__init__(*args, **kwargs)
         self._deferred = False
 
+    @staticmethod
+    def _backend() -> Any:
+        """Return the configured encryption backend, raising if ENCRYPTION_METHOD is unset."""
+
+        if settings.ENCRYPTION_METHOD is None:
+            raise ValueError("ENCRYPTION_METHOD must be set to use SQLAlchemyEncryptedValue.")
+
+        return get_encryption_backend(settings.ENCRYPTION_METHOD)
+
     def _encrypt_cell(self, value: EncryptableValue | EncryptedValue | None) -> EncryptedValue | None:
         """Encode + encrypt a single value, passing pre-encrypted values through."""
 
@@ -33,10 +44,7 @@ class SQLAlchemyEncryptedValue(TypeDecorator):
         if isinstance(value, EncryptedValue):
             return value
 
-        if settings.ENCRYPTION_METHOD is None:
-            raise ValueError("ENCRYPTION_METHOD must be set to use SQLAlchemyEncryptedValue.")
-
-        backend = get_encryption_backend(settings.ENCRYPTION_METHOD)
+        backend = self._backend()
 
         return run_async_or_sync(backend.async_encrypt, backend.encrypt, encode_value(value))
 
@@ -46,10 +54,7 @@ class SQLAlchemyEncryptedValue(TypeDecorator):
         if value is None:
             return None
 
-        if settings.ENCRYPTION_METHOD is None:
-            raise ValueError("ENCRYPTION_METHOD must be set to use SQLAlchemyEncryptedValue.")
-
-        backend = get_encryption_backend(settings.ENCRYPTION_METHOD)
+        backend = self._backend()
 
         return run_async_or_sync(backend.async_decrypt, backend.decrypt, value)
 

--- a/pydantic_encryption/integrations/sqlalchemy/state.py
+++ b/pydantic_encryption/integrations/sqlalchemy/state.py
@@ -35,16 +35,10 @@ def pending_siblings(session: Any, cls: type) -> list[Any]:
 
     if session is None:
         return []
-    info = getattr(session, "info", None)
-    if not info:
-        return []
-    bucket = info.get(PENDING_DECRYPT_KEY)
-    if not bucket:
-        return []
-    siblings = bucket.get(cls)
-    if siblings is None:
-        return []
-    return list(siblings)
+
+    bucket = getattr(session, "info", {}).get(PENDING_DECRYPT_KEY) or {}
+
+    return list(bucket.get(cls) or [])
 
 
 __all__ = ["PENDING_DECRYPT_KEY", "read_raw_cell", "set_decrypted", "pending_siblings"]

--- a/pydantic_encryption/models/base.py
+++ b/pydantic_encryption/models/base.py
@@ -292,14 +292,18 @@ class SecureModel:
 
         if isinstance(value, SecureModel):
             await value.async_post_init()
-        elif isinstance(value, dict):
-            async with asyncio.TaskGroup() as tg:
-                for v in value.values():
-                    tg.create_task(SecureModel._async_post_init_nested(v))
+            return
+
+        if isinstance(value, dict):
+            children: Any = value.values()
         elif isinstance(value, (list, tuple, set, frozenset)):
-            async with asyncio.TaskGroup() as tg:
-                for v in value:
-                    tg.create_task(SecureModel._async_post_init_nested(v))
+            children = value
+        else:
+            return
+
+        async with asyncio.TaskGroup() as tg:
+            for child in children:
+                tg.create_task(SecureModel._async_post_init_nested(child))
 
     async def async_post_init(self) -> None:
         """Run async encrypt + hash + blind-index, including on nested models."""


### PR DESCRIPTION
## Summary

A strict maintainability pass across the adapters, the SQLAlchemy integration, and the model base. All changes are behavior-preserving — public APIs, error messages, and serialized values are unchanged.

### Adapters
- Extracted a single `encode_text(value: str | bytes) -> bytes` helper in `adapters/base.py` and routed the five copy-pasted UTF-8 coercions (`fernet`, `aws`, `argon2`, `hmac_sha256`) through it. `Fernet.decrypt` collapses from a 5-line if/else to one expression.

### SQLAlchemy integration
- `bulk.py`: collapsed the three duplicated "scan rows for encrypted cells" loops (`decrypt_rows`, `decrypt_rows_sync`, `bulk_decrypt_entities`) into one `_collect_row_assignments` helper, so the encrypted-cell collection invariant lives in one place.
- `encryption.py`: extracted a `_backend()` resolver so the "resolve encryption backend or raise" rule is stated once (kept the two distinct error messages by design).
- `blind_index.py`: shared the byte-identical `process_bind_param` / `process_literal_param` bodies via a private `_process` helper (both are required SQLAlchemy `TypeDecorator` hooks).
- `descriptor.py`: adopted the canonical `run_async_or_sync` helper instead of the inline `await_` / `MissingGreenlet` fallback dance.
- `state.py`: flattened `pending_siblings` to a single chained lookup.

### Models
- `models/base.py`: collapsed the near-identical dict-vs-sequence `TaskGroup` loops in `_async_post_init_nested` by resolving the child iterable once.

### Verification
- `pytest tests/unit` → **363 passed**, identical to baseline.
- The integration suite (`tests/integration/test_sqlalchemy.py`) requires a Docker daemon, which is unavailable in this environment; those 33 collection errors are pre-existing/environmental and unrelated to these changes.
- Net: ~74 insertions / 93 deletions.

https://claude.ai/code/session_01PfNPPwW2cfLaSeexRGrhBw

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfNPPwW2cfLaSeexRGrhBw)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactors only; encryption and SQLAlchemy paths are unchanged in behavior per the author’s unit test baseline.
> 
> **Overview**
> This PR is a **behavior-preserving** maintainability pass: public APIs, errors, and serialized values stay the same while duplicated logic moves into shared helpers.
> 
> **Adapters:** A new `encode_text` in `adapters/base.py` replaces repeated `str` → UTF-8 `bytes` handling in Fernet, AWS KMS, Argon2, and HMAC-SHA256 blind-index paths (including a shorter Fernet `decrypt`).
> 
> **SQLAlchemy:** Bulk decrypt paths share `_collect_row_assignments` for scanning encrypted cells; `SQLAlchemyEncryptedValue` resolves the backend via `_backend()`; blind-index bind/literal hooks delegate to `_process`; `DecryptOnAccessDescriptor` uses `run_async_or_sync` instead of inline `await_` / `MissingGreenlet` handling; `pending_siblings` is a single chained lookup.
> 
> **Models:** `SecureModel._async_post_init_nested` uses one `TaskGroup` loop over dict values or sequence children instead of two near-duplicate branches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd0e47e4001787daccf257e6f1adfd02859513f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->