### PR TITLE
refactor: drop leading underscores from non-nested names

### DIFF
--- a/.github/scripts/agent_sync.py
+++ b/.github/scripts/agent_sync.py
@@ -22,7 +22,7 @@ SETTINGS_DIR: Final[Path] = AGENTS_DIR / "settings"
 MODELS_DIR: Final[Path] = AGENTS_DIR / "models"
 MAX_DIFF_LINES: Final[int] = 20
 SAFE_SLUG_PATTERN: Final[re.Pattern[str]] = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
-_TEXT_CACHE: dict[Path, str | None] = {}
+TEXT_CACHE: dict[Path, str | None] = {}
 
 
 class OutputFile(BaseModel):
@@ -691,13 +691,13 @@ def compute_diffs(outputs: list[OutputFile]) -> list[DiffEntry]:
         # Content matches but the exec bit may be missing — rewrite so write_text
         # re-applies chmod. Without this, a Stop hook command pointing at a bare
         # script path can fail.
-        if _output_needs_exec_bit(output) and output.target_path.exists() \
+        if output_needs_exec_bit(output) and output.target_path.exists() \
                 and not output.target_path.stat().st_mode & 0o111:
             diffs.append(DiffEntry(output=output, existing=existing))
     return diffs
 
 
-def _output_needs_exec_bit(output: OutputFile) -> bool:
+def output_needs_exec_bit(output: OutputFile) -> bool:
     return output.target_path.suffix == ".sh" or output.content.startswith("#!")
 
 
@@ -790,15 +790,15 @@ def compute_stale_paths(
 def read_text(path: Path) -> str | None:
     """Read a file with caching to avoid repeated disk reads."""
 
-    if path in _TEXT_CACHE:
-        return _TEXT_CACHE[path]
+    if path in TEXT_CACHE:
+        return TEXT_CACHE[path]
 
     if not path.exists():
-        _TEXT_CACHE[path] = None
+        TEXT_CACHE[path] = None
         return None
 
     content = path.read_text(encoding="utf-8")
-    _TEXT_CACHE[path] = content
+    TEXT_CACHE[path] = content
     return content
 
 
@@ -809,7 +809,7 @@ def write_text(path: Path, content: str) -> None:
     path.write_text(content, encoding="utf-8")
     if path.suffix == ".sh" or content.startswith("#!"):
         path.chmod(0o755)
-    _TEXT_CACHE[path] = content
+    TEXT_CACHE[path] = content
 
 
 def delete_path(path: Path) -> None:
@@ -820,13 +820,13 @@ def delete_path(path: Path) -> None:
 
     if path.is_dir():
         shutil.rmtree(path)
-        stale_keys = [cached_path for cached_path in _TEXT_CACHE if cached_path.is_relative_to(path)]
+        stale_keys = [cached_path for cached_path in TEXT_CACHE if cached_path.is_relative_to(path)]
         for stale_key in stale_keys:
-            _TEXT_CACHE.pop(stale_key, None)
+            TEXT_CACHE.pop(stale_key, None)
         return
 
     path.unlink(missing_ok=True)
-    _TEXT_CACHE.pop(path, None)
+    TEXT_CACHE.pop(path, None)
 
 
 def report_diffs(diffs: list[DiffEntry], stale_paths: list[Path]) -> None:
@@ -936,7 +936,7 @@ def dedupe_directory(directory: Path) -> None:
         keep = choose_preferred(seen[digest], path)
         remove = path if keep == seen[digest] else seen[digest]
         remove.unlink(missing_ok=True)
-        _TEXT_CACHE.pop(remove, None)
+        TEXT_CACHE.pop(remove, None)
         seen[digest] = keep
 
 

--- a/pydantic_encryption/__init__.py
+++ b/pydantic_encryption/__init__.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
     )
 
 
-_LAZY_EXPORTS: dict[str, tuple[str, str]] = {
+LAZY_EXPORTS: dict[str, tuple[str, str]] = {
     "AWSAdapter": ("pydantic_encryption.adapters.encryption.aws", "AWSAdapter"),
     "DeferredDecryptMixin": ("pydantic_encryption.integrations.sqlalchemy", "DeferredDecryptMixin"),
     "SQLAlchemyBlindIndexValue": ("pydantic_encryption.integrations.sqlalchemy", "SQLAlchemyBlindIndexValue"),
@@ -53,7 +53,7 @@ _LAZY_EXPORTS: dict[str, tuple[str, str]] = {
 def __getattr__(name: str):
     """Lazy-load optional symbols (SQLAlchemy / AWS) so the package imports without those extras."""
 
-    target = _LAZY_EXPORTS.get(name)
+    target = LAZY_EXPORTS.get(name)
     if target is None:
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 

--- a/pydantic_encryption/adapters/encryption/aws.py
+++ b/pydantic_encryption/adapters/encryption/aws.py
@@ -25,7 +25,7 @@ NONCE_LENGTH: Final[int] = 12
 DATA_KEY_SPEC: Final[str] = "AES_256"
 
 
-def _to_bytes(ciphertext: bytes | str | EncryptedValue) -> bytes:
+def to_bytes(ciphertext: bytes | str | EncryptedValue) -> bytes:
     """Coerce decrypt() inputs to raw bytes preserving every original byte value 1:1."""
 
     if isinstance(ciphertext, str):
@@ -34,7 +34,7 @@ def _to_bytes(ciphertext: bytes | str | EncryptedValue) -> bytes:
     return bytes(ciphertext)
 
 
-def _kms_kwargs() -> dict[str, str]:
+def kms_kwargs() -> dict[str, str]:
     """Return boto3/aioboto3 kwargs for the configured KMS region + credentials."""
 
     has_key = (
@@ -61,7 +61,7 @@ def _kms_kwargs() -> dict[str, str]:
     }
 
 
-def _seal(plaintext_data_key: bytes, wrapped_data_key: bytes, plaintext: bytes) -> EncryptedValue:
+def seal(plaintext_data_key: bytes, wrapped_data_key: bytes, plaintext: bytes) -> EncryptedValue:
     """Wrap plaintext under a fresh AES-GCM nonce and pack ``[magic][ver][wrapped][nonce][sealed]``."""
 
     nonce = secrets.token_bytes(NONCE_LENGTH)
@@ -75,7 +75,7 @@ def _seal(plaintext_data_key: bytes, wrapped_data_key: bytes, plaintext: bytes) 
     )
 
 
-def _open(blob: bytes) -> tuple[bytes, bytes, bytes]:
+def open(blob: bytes) -> tuple[bytes, bytes, bytes]:
     """Validate the envelope header and split into ``(wrapped_data_key, nonce, sealed)``."""
 
     if len(blob) < HEADER_LENGTH:
@@ -108,7 +108,7 @@ class AWSAdapter(EncryptionAdapter):
     _async_init_lock: ClassVar[asyncio.Lock | None] = None
 
     @classmethod
-    def _encrypt_arn(cls) -> str:
+    def encrypt_arn(cls) -> str:
         """Return the encryption ARN, rejecting decrypt-only (read-only) configurations."""
 
         arn = settings.AWS_KMS_ENCRYPT_KEY_ARN or settings.AWS_KMS_KEY_ARN
@@ -121,7 +121,7 @@ class AWSAdapter(EncryptionAdapter):
         return arn
 
     @classmethod
-    def _decrypt_kwargs(cls, wrapped_data_key: bytes) -> dict[str, Any]:
+    def decrypt_kwargs(cls, wrapped_data_key: bytes) -> dict[str, Any]:
         """Build ``KMS.Decrypt`` kwargs, scoping by KeyId when one is configured."""
 
         kwargs: dict[str, Any] = {"CiphertextBlob": wrapped_data_key}
@@ -132,16 +132,16 @@ class AWSAdapter(EncryptionAdapter):
         return kwargs
 
     @classmethod
-    def _sync_kms(cls) -> Any:
+    def sync_kms(cls) -> Any:
         """Return the lazily-built sync boto3 KMS client used by sync code paths."""
 
         if cls._sync_client is None:
-            cls._sync_client = boto3.client("kms", **_kms_kwargs())
+            cls._sync_client = boto3.client("kms", **kms_kwargs())
 
         return cls._sync_client
 
     @classmethod
-    async def _async_kms(cls) -> Any:
+    async def async_kms(cls) -> Any:
         """Return the lazily-built aioboto3 KMS client, opened once per event loop."""
 
         loop = asyncio.get_running_loop()
@@ -155,7 +155,7 @@ class AWSAdapter(EncryptionAdapter):
             if cls._async_client is not None and cls._async_loop is loop:
                 return cls._async_client
 
-            ctx = aioboto3.Session(**_kms_kwargs()).client("kms")
+            ctx = aioboto3.Session(**kms_kwargs()).client("kms")
             cls._async_client = await ctx.__aenter__()
             cls._async_client_ctx = ctx
             cls._async_loop = loop
@@ -180,9 +180,9 @@ class AWSAdapter(EncryptionAdapter):
         if isinstance(plaintext, EncryptedValue):
             return plaintext
 
-        response = cls._sync_kms().generate_data_key(KeyId=cls._encrypt_arn(), KeySpec=DATA_KEY_SPEC)
+        response = cls.sync_kms().generate_data_key(KeyId=cls.encrypt_arn(), KeySpec=DATA_KEY_SPEC)
 
-        return _seal(response["Plaintext"], response["CiphertextBlob"], encode_text(plaintext))
+        return seal(response["Plaintext"], response["CiphertextBlob"], encode_text(plaintext))
 
     @classmethod
     async def async_encrypt(
@@ -191,16 +191,16 @@ class AWSAdapter(EncryptionAdapter):
         if isinstance(plaintext, EncryptedValue):
             return plaintext
 
-        kms = await cls._async_kms()
-        response = await kms.generate_data_key(KeyId=cls._encrypt_arn(), KeySpec=DATA_KEY_SPEC)
+        kms = await cls.async_kms()
+        response = await kms.generate_data_key(KeyId=cls.encrypt_arn(), KeySpec=DATA_KEY_SPEC)
 
-        return _seal(response["Plaintext"], response["CiphertextBlob"], encode_text(plaintext))
+        return seal(response["Plaintext"], response["CiphertextBlob"], encode_text(plaintext))
 
     @classmethod
     def decrypt(cls, ciphertext: bytes | str | EncryptedValue, *, key: str | None = None) -> str:
-        wrapped, nonce, sealed = _open(_to_bytes(ciphertext))
+        wrapped, nonce, sealed = open(to_bytes(ciphertext))
 
-        plaintext_data_key = cls._sync_kms().decrypt(**cls._decrypt_kwargs(wrapped))["Plaintext"]
+        plaintext_data_key = cls.sync_kms().decrypt(**cls.decrypt_kwargs(wrapped))["Plaintext"]
 
         return AESGCM(plaintext_data_key).decrypt(nonce, sealed, None).decode("utf-8")
 
@@ -208,9 +208,9 @@ class AWSAdapter(EncryptionAdapter):
     async def async_decrypt(
         cls, ciphertext: bytes | str | EncryptedValue, *, key: str | None = None
     ) -> str:
-        wrapped, nonce, sealed = _open(_to_bytes(ciphertext))
+        wrapped, nonce, sealed = open(to_bytes(ciphertext))
 
-        kms = await cls._async_kms()
-        response = await kms.decrypt(**cls._decrypt_kwargs(wrapped))
+        kms = await cls.async_kms()
+        response = await kms.decrypt(**cls.decrypt_kwargs(wrapped))
 
         return AESGCM(response["Plaintext"]).decrypt(nonce, sealed, None).decode("utf-8")

--- a/pydantic_encryption/adapters/encryption/fernet.py
+++ b/pydantic_encryption/adapters/encryption/fernet.py
@@ -14,7 +14,7 @@ class FernetAdapter(EncryptionAdapter):
     _clients: ClassVar[dict[str, Fernet]] = {}
 
     @classmethod
-    def _get_client(cls, key: str | None = None) -> Fernet:
+    def get_client(cls, key: str | None = None) -> Fernet:
         """Return a cached Fernet client for the given key (defaults to settings.ENCRYPTION_KEY)."""
 
         resolved = key or settings.ENCRYPTION_KEY
@@ -30,12 +30,12 @@ class FernetAdapter(EncryptionAdapter):
         if isinstance(plaintext, EncryptedValue):
             return plaintext
 
-        client = cls._get_client(key)
+        client = cls.get_client(key)
         return EncryptedValue(client.encrypt(encode_text(plaintext)))
 
     @classmethod
     def decrypt(cls, ciphertext: str | bytes | EncryptedValue, *, key: str | None = None) -> str:
-        client = cls._get_client(key)
+        client = cls.get_client(key)
         return client.decrypt(encode_text(ciphertext)).decode("utf-8")
 
 

--- a/pydantic_encryption/adapters/hashing/argon2.py
+++ b/pydantic_encryption/adapters/hashing/argon2.py
@@ -12,7 +12,7 @@ class Argon2Adapter(HashingAdapter):
     _hasher: ClassVar[PasswordHasher | None] = None
 
     @classmethod
-    def _get_hasher(cls) -> PasswordHasher:
+    def get_hasher(cls) -> PasswordHasher:
         if cls._hasher is None:
             cls._hasher = PasswordHasher()
 
@@ -25,7 +25,7 @@ class Argon2Adapter(HashingAdapter):
         if isinstance(value, HashedValue):
             return value
 
-        hasher = cls._get_hasher()
+        hasher = cls.get_hasher()
         hashed_value = HashedValue(hasher.hash(value))
 
         return hashed_value

--- a/pydantic_encryption/adapters/registry.py
+++ b/pydantic_encryption/adapters/registry.py
@@ -5,54 +5,54 @@ from typing import Callable
 
 from pydantic_encryption.types import BlindIndexMethod, EncryptionMethod
 
-_encryption_backends: dict[EncryptionMethod, type] = {}
-_encryption_factories: dict[EncryptionMethod, Callable[[], type]] = {}
-_blind_index_backends: dict[BlindIndexMethod, type] = {}
+encryption_backends: dict[EncryptionMethod, type] = {}
+encryption_factories: dict[EncryptionMethod, Callable[[], type]] = {}
+blind_index_backends: dict[BlindIndexMethod, type] = {}
 
-_registry_lock = threading.Lock()
+registry_lock = threading.Lock()
 
 
 def register_encryption_backend(method: EncryptionMethod, cls: type) -> None:
-    _encryption_backends[method] = cls
+    encryption_backends[method] = cls
 
 
 def register_encryption_backend_lazy(method: EncryptionMethod, factory: Callable[[], type]) -> None:
-    _encryption_factories[method] = factory
+    encryption_factories[method] = factory
 
 
 def get_encryption_backend(method: EncryptionMethod) -> type:
-    if method in _encryption_backends:
-        return _encryption_backends[method]
-    with _registry_lock:
-        if method in _encryption_backends:
-            return _encryption_backends[method]
-        factory = _encryption_factories.get(method)
+    if method in encryption_backends:
+        return encryption_backends[method]
+    with registry_lock:
+        if method in encryption_backends:
+            return encryption_backends[method]
+        factory = encryption_factories.get(method)
         if factory is not None:
             # Invoke first; only remove from factories on success so a failing
             # factory (e.g. missing optional dep) stays retryable and surfaces
             # its real ImportError instead of a generic "no backend" ValueError.
             cls = factory()
-            _encryption_backends[method] = cls
-            del _encryption_factories[method]
+            encryption_backends[method] = cls
+            del encryption_factories[method]
             return cls
     raise ValueError(f"No encryption backend registered for {method!r}")
 
 
 def register_blind_index_backend(method: BlindIndexMethod, cls: type) -> None:
-    _blind_index_backends[method] = cls
+    blind_index_backends[method] = cls
 
 
 def get_blind_index_backend(method: BlindIndexMethod) -> type:
-    if method in _blind_index_backends:
-        return _blind_index_backends[method]
+    if method in blind_index_backends:
+        return blind_index_backends[method]
     raise ValueError(f"No blind index backend registered for {method!r}")
 
 
 # Register lazy-loaded backends for optional dependencies
-def _load_aws_adapter():
+def load_aws_adapter():
     from pydantic_encryption.adapters.encryption.aws import AWSAdapter
 
     return AWSAdapter
 
 
-register_encryption_backend_lazy(EncryptionMethod.AWS, _load_aws_adapter)
+register_encryption_backend_lazy(EncryptionMethod.AWS, load_aws_adapter)

--- a/pydantic_encryption/integrations/sqlalchemy/blind_index.py
+++ b/pydantic_encryption/integrations/sqlalchemy/blind_index.py
@@ -42,7 +42,7 @@ class SQLAlchemyBlindIndexValue(TypeDecorator):
         self.normalize_to_lowercase = normalize_to_lowercase
         self.normalize_to_uppercase = normalize_to_uppercase
 
-    def _key_bytes(self) -> bytes:
+    def key_bytes(self) -> bytes:
         """Return the configured BLIND_INDEX_SECRET_KEY as utf-8 bytes."""
 
         if settings.BLIND_INDEX_SECRET_KEY is None:
@@ -50,7 +50,7 @@ class SQLAlchemyBlindIndexValue(TypeDecorator):
 
         return settings.BLIND_INDEX_SECRET_KEY.encode("utf-8")
 
-    def _normalize(self, value: str | bytes) -> str | bytes:
+    def normalize(self, value: str | bytes) -> str | bytes:
         """Apply the configured normalization flags. Bytes values pass through unchanged."""
 
         if isinstance(value, bytes):
@@ -65,18 +65,18 @@ class SQLAlchemyBlindIndexValue(TypeDecorator):
             normalize_to_uppercase=self.normalize_to_uppercase,
         )
 
-    def _compute_blind_index(self, value: str | bytes) -> bytes:
+    def compute_blind_index(self, value: str | bytes) -> bytes:
         """Compute a deterministic blind index for the given value."""
 
-        key = self._key_bytes()
-        value = self._normalize(value)
+        key = self.key_bytes()
+        value = self.normalize(value)
         backend = get_blind_index_backend(self.method)
 
         return run_async_or_sync(
             backend.async_compute_blind_index, backend.compute_blind_index, value, key
         )
 
-    def _process(self, value: str | bytes | BlindIndexValue | None) -> bytes | None:
+    def process(self, value: str | bytes | BlindIndexValue | None) -> bytes | None:
         """Compute the blind index, passing ``None`` and pre-indexed values through."""
 
         if value is None:
@@ -85,17 +85,17 @@ class SQLAlchemyBlindIndexValue(TypeDecorator):
         if isinstance(value, BlindIndexValue):
             return value
 
-        return self._compute_blind_index(value)
+        return self.compute_blind_index(value)
 
     def process_bind_param(self, value: str | bytes | BlindIndexValue | None, dialect) -> bytes | None:
         """Compute the blind index before binding to the database."""
 
-        return self._process(value)
+        return self.process(value)
 
     def process_literal_param(self, value: str | bytes | BlindIndexValue | None, dialect) -> bytes | None:
         """Compute the blind index for literal SQL expressions."""
 
-        return self._process(value)
+        return self.process(value)
 
     def process_result_value(self, value: bytes | None, dialect) -> BlindIndexValue | None:
         """Return the stored blind index wrapped as a ``BlindIndexValue``."""

--- a/pydantic_encryption/integrations/sqlalchemy/bulk.py
+++ b/pydantic_encryption/integrations/sqlalchemy/bulk.py
@@ -26,13 +26,13 @@ from pydantic_encryption.integrations.sqlalchemy.state import (
 from pydantic_encryption.types import EncryptedValue
 
 
-def _column_key(column: InstrumentedAttribute | str) -> str:
+def column_key(column: InstrumentedAttribute | str) -> str:
     """Return the column key for an InstrumentedAttribute or string column name."""
 
     return column if isinstance(column, str) else column.key
 
 
-def _resolve_backend() -> Any:
+def resolve_backend() -> Any:
     """Return the configured encryption backend, raising if ENCRYPTION_METHOD is unset."""
 
     method = settings.ENCRYPTION_METHOD
@@ -42,7 +42,7 @@ def _resolve_backend() -> Any:
     return get_encryption_backend(method)
 
 
-def _collect_row_assignments(
+def collect_row_assignments(
     rows: Iterable[Any], column_keys: Iterable[str]
 ) -> list[tuple[Any, str, bytes]]:
     """Build ``(row, key, ciphertext)`` triples for every encrypted cell across rows."""
@@ -58,7 +58,7 @@ def _collect_row_assignments(
     return assignments
 
 
-async def _decrypt_assignments(
+async def decrypt_assignments(
     backend: Any, assignments: list[tuple[Any, str, bytes]]
 ) -> None:
     """Decrypt every ``(row, key, ciphertext)`` triple under a TaskGroup and write results back.
@@ -88,10 +88,10 @@ async def decrypt_rows(rows: Iterable[Any], *columns: InstrumentedAttribute | st
     if not columns:
         return
 
-    backend = _resolve_backend()
-    assignments = _collect_row_assignments(rows, (_column_key(c) for c in columns))
+    backend = resolve_backend()
+    assignments = collect_row_assignments(rows, (column_key(c) for c in columns))
 
-    await _decrypt_assignments(backend, assignments)
+    await decrypt_assignments(backend, assignments)
 
 
 def decrypt_rows_sync(rows: Iterable[Any], *columns: InstrumentedAttribute | str) -> None:
@@ -100,8 +100,8 @@ def decrypt_rows_sync(rows: Iterable[Any], *columns: InstrumentedAttribute | str
     if not columns:
         return
 
-    backend = _resolve_backend()
-    for row, key, ciphertext in _collect_row_assignments(rows, (_column_key(c) for c in columns)):
+    backend = resolve_backend()
+    for row, key, ciphertext in collect_row_assignments(rows, (column_key(c) for c in columns)):
         set_decrypted(row, key, decode_value(backend.decrypt(ciphertext)))
 
 
@@ -112,7 +112,7 @@ async def decrypt_values(values: Iterable[Any]) -> list[Any]:
     if not values_list:
         return []
 
-    backend = _resolve_backend()
+    backend = resolve_backend()
     indexes: list[int] = []
     encrypted_blobs: list[bytes] = []
     for index, value in enumerate(values_list):
@@ -189,12 +189,12 @@ async def bulk_decrypt_entities(entities: Any | Iterable[Any] | None) -> None:
     if not collected:
         return
 
-    backend = _resolve_backend()
+    backend = resolve_backend()
     assignments: list[tuple[Any, str, bytes]] = []
     for (_, column_key), rows in collected.items():
-        assignments.extend(_collect_row_assignments(rows, (column_key,)))
+        assignments.extend(collect_row_assignments(rows, (column_key,)))
 
-    await _decrypt_assignments(backend, assignments)
+    await decrypt_assignments(backend, assignments)
 
 
 async def decrypt_pending_fields(session: AsyncSession) -> None:

--- a/pydantic_encryption/integrations/sqlalchemy/encryption.py
+++ b/pydantic_encryption/integrations/sqlalchemy/encryption.py
@@ -28,7 +28,7 @@ class SQLAlchemyEncryptedValue(TypeDecorator):
         self._deferred = False
 
     @staticmethod
-    def _backend() -> Any:
+    def backend() -> Any:
         """Return the configured encryption backend, raising if ENCRYPTION_METHOD is unset."""
 
         if settings.ENCRYPTION_METHOD is None:
@@ -36,7 +36,7 @@ class SQLAlchemyEncryptedValue(TypeDecorator):
 
         return get_encryption_backend(settings.ENCRYPTION_METHOD)
 
-    def _encrypt_cell(self, value: EncryptableValue | EncryptedValue | None) -> EncryptedValue | None:
+    def encrypt_cell(self, value: EncryptableValue | EncryptedValue | None) -> EncryptedValue | None:
         """Encode + encrypt a single value, passing pre-encrypted values through."""
 
         if value is None:
@@ -44,29 +44,29 @@ class SQLAlchemyEncryptedValue(TypeDecorator):
         if isinstance(value, EncryptedValue):
             return value
 
-        backend = self._backend()
+        backend = self.backend()
 
         return run_async_or_sync(backend.async_encrypt, backend.encrypt, encode_value(value))
 
-    def _decrypt_cell(self, value: str | bytes | None) -> str | bytes | None:
+    def decrypt_cell(self, value: str | bytes | None) -> str | bytes | None:
         """Decrypt a single ciphertext; callers are responsible for decoding."""
 
         if value is None:
             return None
 
-        backend = self._backend()
+        backend = self.backend()
 
         return run_async_or_sync(backend.async_decrypt, backend.decrypt, value)
 
     def process_bind_param(self, value: EncryptableValue | None, dialect) -> bytes | None:
         """Encrypt a value before binding it to the database."""
 
-        return self._encrypt_cell(value)
+        return self.encrypt_cell(value)
 
     def process_literal_param(self, value: EncryptableValue | None, dialect) -> bytes | None:
         """Encrypt a value for literal SQL expressions."""
 
-        return self._encrypt_cell(value)
+        return self.encrypt_cell(value)
 
     def process_result_value(self, value: str | bytes | None, dialect) -> EncryptableValue | None:
         """Decrypt a value after retrieving it from the database."""
@@ -77,7 +77,7 @@ class SQLAlchemyEncryptedValue(TypeDecorator):
         if self._deferred:
             return EncryptedValue(value)
 
-        return decode_value(self._decrypt_cell(value))
+        return decode_value(self.decrypt_cell(value))
 
     @property
     def python_type(self):
@@ -102,7 +102,7 @@ class SQLAlchemyPGEncryptedArray(TypeDecorator):
         if value is None:
             return None
 
-        return [self._element_type._encrypt_cell(element) for element in value]
+        return [self._element_type.encrypt_cell(element) for element in value]
 
     def process_literal_param(self, value: list[EncryptableValue] | None, dialect) -> list[bytes] | None:
         """Encrypt each element for literal SQL expressions."""
@@ -110,7 +110,7 @@ class SQLAlchemyPGEncryptedArray(TypeDecorator):
         if value is None:
             return None
 
-        return [self._element_type._encrypt_cell(element) for element in value]
+        return [self._element_type.encrypt_cell(element) for element in value]
 
     def process_result_value(self, value: list[bytes] | None, dialect) -> list[EncryptableValue] | None:
         """Decrypt each element after retrieving the array from the database."""
@@ -119,7 +119,7 @@ class SQLAlchemyPGEncryptedArray(TypeDecorator):
             return None
 
         return [
-            None if element is None else decode_value(self._element_type._decrypt_cell(element))
+            None if element is None else decode_value(self._element_type.decrypt_cell(element))
             for element in value
         ]
 

--- a/pydantic_encryption/integrations/sqlalchemy/hashing.py
+++ b/pydantic_encryption/integrations/sqlalchemy/hashing.py
@@ -15,7 +15,7 @@ class SQLAlchemyHashedValue(TypeDecorator):
     impl = LargeBinary
     cache_ok = True
 
-    def _hash(self, value: str | bytes) -> HashedValue:
+    def hash(self, value: str | bytes) -> HashedValue:
         return run_async_or_sync(Argon2Adapter.async_hash, Argon2Adapter.hash, value)
 
     def process_bind_param(self, value: str | bytes | None, dialect) -> bytes | None:
@@ -24,7 +24,7 @@ class SQLAlchemyHashedValue(TypeDecorator):
         if value is None:
             return None
 
-        return self._hash(value)
+        return self.hash(value)
 
     def process_literal_param(self, value: str | bytes | None, dialect) -> HashedValue | None:
         """Hash a value for literal SQL expressions."""
@@ -32,7 +32,7 @@ class SQLAlchemyHashedValue(TypeDecorator):
         if value is None:
             return None
 
-        return dialect.literal_processor(self.impl)(self._hash(value))
+        return dialect.literal_processor(self.impl)(self.hash(value))
 
     def process_result_value(self, value: str | bytes | None, dialect) -> HashedValue | None:
         """Return the stored hash wrapped as a ``HashedValue``."""

--- a/pydantic_encryption/models/base.py
+++ b/pydantic_encryption/models/base.py
@@ -14,8 +14,8 @@ from pydantic_encryption.types import BlindIndex, BlindIndexValue, Encrypted, En
 
 __all__ = ["BaseModel", "SecureModel"]
 
-_defer_crypto_to_async: contextvars.ContextVar[bool] = contextvars.ContextVar(
-    "_defer_crypto_to_async", default=False
+defer_crypto_to_async: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "defer_crypto_to_async", default=False
 )
 
 
@@ -48,7 +48,7 @@ class SecureModel:
             cls._blind_index_key = blind_index_key
 
     @classmethod
-    def _resolve_encryption_method(cls) -> EncryptionMethod:
+    def resolve_encryption_method(cls) -> EncryptionMethod:
         """Return the per-class override or the ENCRYPTION_METHOD env value."""
 
         method = cls._encryption_method or settings.ENCRYPTION_METHOD
@@ -58,13 +58,13 @@ class SecureModel:
         return method
 
     @classmethod
-    def _resolve_encryption_key(cls) -> str | None:
+    def resolve_encryption_key(cls) -> str | None:
         """Return the per-class override or the ENCRYPTION_KEY env value."""
 
         return cls._encryption_key or settings.ENCRYPTION_KEY
 
     @classmethod
-    def _resolve_blind_index_key(cls) -> str:
+    def resolve_blind_index_key(cls) -> str:
         """Return the per-class override or the BLIND_INDEX_SECRET_KEY env value."""
 
         key = cls._blind_index_key or settings.BLIND_INDEX_SECRET_KEY
@@ -92,7 +92,7 @@ class SecureModel:
         return self.get_annotated_fields(BlindIndex)
 
     @staticmethod
-    def _nonempty_field_values(fields: dict[str, AnnotatedFieldInfo]) -> dict[str, Any]:
+    def nonempty_field_values(fields: dict[str, AnnotatedFieldInfo]) -> dict[str, Any]:
         """Extract raw values from annotated field info, dropping ``None`` entries."""
 
         return {
@@ -101,7 +101,7 @@ class SecureModel:
             if annotated_field.value is not None
         }
 
-    def _collect_encryption_fields(
+    def collect_encryption_fields(
         self,
     ) -> tuple[type[EncryptionAdapter], str | None, dict[str, Any]] | None:
         """Resolve encryption backend/key and collect field values."""
@@ -109,25 +109,25 @@ class SecureModel:
         if not self.pending_encryption_fields:
             return None
 
-        fields = self._nonempty_field_values(self.pending_encryption_fields)
+        fields = self.nonempty_field_values(self.pending_encryption_fields)
         if not fields:
             return None
 
-        backend = get_encryption_backend(self._resolve_encryption_method())
-        key = self._resolve_encryption_key()
+        backend = get_encryption_backend(self.resolve_encryption_method())
+        key = self.resolve_encryption_key()
 
         return backend, key, fields
 
-    def _collect_hash_fields(self) -> dict[str, Any] | None:
+    def collect_hash_fields(self) -> dict[str, Any] | None:
         """Collect non-``None`` values for fields annotated with ``Hashed``."""
 
         if not self.pending_hash_fields:
             return None
 
-        fields = self._nonempty_field_values(self.pending_hash_fields)
+        fields = self.nonempty_field_values(self.pending_hash_fields)
         return fields or None
 
-    def _normalize_blind_index_value(self, annotation: BlindIndex, value: Any) -> str:
+    def normalize_blind_index_value(self, annotation: BlindIndex, value: Any) -> str:
         """Decode bytes to str and apply the annotation's normalization flags."""
 
         if isinstance(value, bytes):
@@ -142,7 +142,7 @@ class SecureModel:
             normalize_to_uppercase=annotation.normalize_to_uppercase,
         )
 
-    def _collect_blind_index_tasks(
+    def collect_blind_index_tasks(
         self,
     ) -> list[tuple[str, type[BlindIndexAdapter], str, bytes]] | None:
         """Return ``(field_name, backend, normalized_value, key_bytes)`` tuples."""
@@ -159,17 +159,17 @@ class SecureModel:
                 continue
 
             annotation: BlindIndex = annotated_field.matched_metadata[0]
-            normalized = self._normalize_blind_index_value(annotation, value)
+            normalized = self.normalize_blind_index_value(annotation, value)
 
             if key_bytes is None:
-                key_bytes = self._resolve_blind_index_key().encode("utf-8")
+                key_bytes = self.resolve_blind_index_key().encode("utf-8")
 
             backend = get_blind_index_backend(annotation.method)
             tasks.append((field_name, backend, normalized, key_bytes))
 
         return tasks or None
 
-    async def _async_apply(self, items: list[tuple[str, Awaitable[Any]]]) -> None:
+    async def async_apply(self, items: list[tuple[str, Awaitable[Any]]]) -> None:
         """Await each coroutine under a TaskGroup and ``setattr`` its result onto ``self``."""
 
         if not items:
@@ -184,7 +184,7 @@ class SecureModel:
     def encrypt_data(self) -> None:
         """Encrypt fields annotated with ``Encrypted`` in-place."""
 
-        collected = self._collect_encryption_fields()
+        collected = self.collect_encryption_fields()
         if collected is None:
             return
 
@@ -195,7 +195,7 @@ class SecureModel:
     def hash_data(self) -> None:
         """Hash fields annotated with ``Hashed`` in-place."""
 
-        fields = self._collect_hash_fields()
+        fields = self.collect_hash_fields()
         if fields is None:
             return
 
@@ -205,7 +205,7 @@ class SecureModel:
     def blind_index_data(self) -> None:
         """Compute blind indexes for fields annotated with ``BlindIndex`` in-place."""
 
-        tasks = self._collect_blind_index_tasks()
+        tasks = self.collect_blind_index_tasks()
         if tasks is None:
             return
 
@@ -215,7 +215,7 @@ class SecureModel:
     def decrypt_data(self) -> Self:
         """Decrypt all ``Encrypted`` fields in-place and return ``self`` for chaining."""
 
-        collected = self._collect_encryption_fields()
+        collected = self.collect_encryption_fields()
         if collected is None:
             return self
 
@@ -228,34 +228,34 @@ class SecureModel:
     async def async_encrypt_data(self) -> None:
         """Asynchronously encrypt fields annotated with ``Encrypted``."""
 
-        collected = self._collect_encryption_fields()
+        collected = self.collect_encryption_fields()
         if collected is None:
             return
 
         backend, key, fields = collected
-        await self._async_apply(
+        await self.async_apply(
             [(name, backend.async_encrypt(val, key=key)) for name, val in fields.items()]
         )
 
     async def async_hash_data(self) -> None:
         """Asynchronously hash fields annotated with ``Hashed``."""
 
-        fields = self._collect_hash_fields()
+        fields = self.collect_hash_fields()
         if fields is None:
             return
 
-        await self._async_apply(
+        await self.async_apply(
             [(name, hashing.argon2.Argon2Adapter.async_hash(val)) for name, val in fields.items()]
         )
 
     async def async_blind_index_data(self) -> None:
         """Asynchronously compute blind indexes for fields annotated with ``BlindIndex``."""
 
-        tasks = self._collect_blind_index_tasks()
+        tasks = self.collect_blind_index_tasks()
         if tasks is None:
             return
 
-        await self._async_apply(
+        await self.async_apply(
             [
                 (name, backend.async_compute_blind_index(value, key_bytes))
                 for name, backend, value, key_bytes in tasks
@@ -265,12 +265,12 @@ class SecureModel:
     async def async_decrypt_data(self) -> Self:
         """Asynchronously decrypt all ``Encrypted`` fields and return ``self`` for chaining."""
 
-        collected = self._collect_encryption_fields()
+        collected = self.collect_encryption_fields()
         if collected is None:
             return self
 
         backend, key, fields = collected
-        await self._async_apply(
+        await self.async_apply(
             [(name, backend.async_decrypt(val, key=key)) for name, val in fields.items()]
         )
 
@@ -279,7 +279,7 @@ class SecureModel:
     def default_post_init(self) -> None:
         """Post-initialization hook that runs sync encrypt + hash + blind-index."""
 
-        if _defer_crypto_to_async.get():
+        if defer_crypto_to_async.get():
             return
 
         self.encrypt_data()
@@ -287,7 +287,7 @@ class SecureModel:
         self.blind_index_data()
 
     @staticmethod
-    async def _async_post_init_nested(value: Any) -> None:
+    async def async_post_init_nested(value: Any) -> None:
         """Recursively run ``async_post_init`` on nested ``SecureModel`` instances."""
 
         if isinstance(value, SecureModel):
@@ -303,7 +303,7 @@ class SecureModel:
 
         async with asyncio.TaskGroup() as tg:
             for child in children:
-                tg.create_task(SecureModel._async_post_init_nested(child))
+                tg.create_task(SecureModel.async_post_init_nested(child))
 
     async def async_post_init(self) -> None:
         """Run async encrypt + hash + blind-index, including on nested models."""
@@ -312,7 +312,7 @@ class SecureModel:
             for name in getattr(type(self), "model_fields", {}):
                 value = getattr(self, name, None)
                 if value is not None:
-                    tg.create_task(self._async_post_init_nested(value))
+                    tg.create_task(self.async_post_init_nested(value))
             tg.create_task(self.async_encrypt_data())
             tg.create_task(self.async_hash_data())
             tg.create_task(self.async_blind_index_data())
@@ -334,10 +334,10 @@ class BaseModel(SuperModelPydanticMixin, SecureModel):
     async def async_init(cls, /, **data: Any) -> Self:
         """Construct a model with async encryption, hashing, and blind indexing."""
 
-        token = _defer_crypto_to_async.set(True)
+        token = defer_crypto_to_async.set(True)
         try:
             instance = cls(**data)
         finally:
-            _defer_crypto_to_async.reset(token)
+            defer_crypto_to_async.reset(token)
         await instance.async_post_init()
         return instance

--- a/pydantic_encryption/types.py
+++ b/pydantic_encryption/types.py
@@ -29,7 +29,7 @@ class EncryptedValueAccessError(RuntimeError):
     """Raised when an encrypted ciphertext is coerced to str before decryption."""
 
 
-class _TaggedBytes(bytes):
+class TaggedBytes(bytes):
     """Bytes subclass that UTF-8-encodes ``str`` inputs."""
 
     def __new__(cls, value: str | bytes):
@@ -41,7 +41,7 @@ class _TaggedBytes(bytes):
         return f"<{type(self).__name__}: {len(self)} bytes>"
 
 
-class EncryptedValue(_TaggedBytes):
+class EncryptedValue(TaggedBytes):
     """Bytes subclass representing an encrypted ciphertext; ``str()`` raises to flag accidental coercion."""
 
     def __str__(self) -> str:
@@ -53,11 +53,11 @@ class EncryptedValue(_TaggedBytes):
         )
 
 
-class HashedValue(_TaggedBytes):
+class HashedValue(TaggedBytes):
     """Bytes subclass representing a hashed value."""
 
 
-class BlindIndexValue(_TaggedBytes):
+class BlindIndexValue(TaggedBytes):
     """Bytes subclass representing a blind index value."""
 
 

--- a/tests/integration/test_sqlalchemy.py
+++ b/tests/integration/test_sqlalchemy.py
@@ -25,7 +25,7 @@ TEST_SESSION_DURATION: Final[timedelta] = timedelta(hours=2, minutes=30)
 class TestIntegrationSQLAlchemy:
     """Test the integration with SQLAlchemy."""
 
-    def _create_user(
+    def create_user(
         self,
         db_session: Session,
         username: str,
@@ -72,7 +72,7 @@ class TestIntegrationSQLAlchemy:
     def test_secure_fields(self, db_session: Session):
         """Test encrypting and hashing fields with the SQLAlchemyEncryptedValue and SQLAlchemyHashedValue types."""
 
-        user = self._create_user(db_session, username="user1", password=TEST_PASSWORD)
+        user = self.create_user(db_session, username="user1", password=TEST_PASSWORD)
 
         assert user.username == "user1"
         assert user.email == TEST_EMAIL
@@ -81,7 +81,7 @@ class TestIntegrationSQLAlchemy:
     def test_encrypt_decrypt_date(self, db_session: Session):
         """Test that date fields are encrypted and decrypted correctly."""
 
-        user = self._create_user(
+        user = self.create_user(
             db_session, username="user2", password=TEST_PASSWORD, birth_date=TEST_BIRTH_DATE
         )
 
@@ -91,7 +91,7 @@ class TestIntegrationSQLAlchemy:
     def test_encrypt_decrypt_datetime(self, db_session: Session):
         """Test that datetime fields are encrypted and decrypted correctly."""
 
-        user = self._create_user(
+        user = self.create_user(
             db_session, username="user3", password=TEST_PASSWORD, last_login=TEST_LAST_LOGIN
         )
 
@@ -103,7 +103,7 @@ class TestIntegrationSQLAlchemy:
 
         test_datetime = datetime(2025, 1, 21, 14, 30, 45, tzinfo=timezone.utc)
 
-        user = self._create_user(
+        user = self.create_user(
             db_session, username="user4", password=TEST_PASSWORD, last_login=test_datetime
         )
 
@@ -113,7 +113,7 @@ class TestIntegrationSQLAlchemy:
     def test_null_date_handling(self, db_session: Session):
         """Test that None values are handled correctly."""
 
-        user = self._create_user(
+        user = self.create_user(
             db_session, username="user5", password=TEST_PASSWORD, birth_date=None, last_login=None
         )
 
@@ -123,7 +123,7 @@ class TestIntegrationSQLAlchemy:
     def test_encrypt_decrypt_int(self, db_session: Session):
         """Test that integer fields are encrypted and decrypted correctly."""
 
-        user = self._create_user(db_session, username="user6", password=TEST_PASSWORD, age=TEST_AGE)
+        user = self.create_user(db_session, username="user6", password=TEST_PASSWORD, age=TEST_AGE)
 
         assert user.age == TEST_AGE
         assert isinstance(user.age, int)
@@ -131,7 +131,7 @@ class TestIntegrationSQLAlchemy:
     def test_encrypt_decrypt_bytes(self, db_session: Session):
         """Test that bytes fields are encrypted and decrypted correctly."""
 
-        user = self._create_user(
+        user = self.create_user(
             db_session, username="user7", password=TEST_PASSWORD, secret_data=TEST_SECRET_DATA
         )
 
@@ -141,7 +141,7 @@ class TestIntegrationSQLAlchemy:
     def test_encrypt_decrypt_str(self, db_session: Session):
         """Test that string fields are encrypted and decrypted correctly."""
 
-        user = self._create_user(db_session, username="user8", password=TEST_PASSWORD)
+        user = self.create_user(db_session, username="user8", password=TEST_PASSWORD)
 
         assert user.email == TEST_EMAIL
         assert isinstance(user.email, str)
@@ -149,7 +149,7 @@ class TestIntegrationSQLAlchemy:
     def test_encrypt_decrypt_bool_true(self, db_session: Session):
         """Test that boolean True is encrypted and decrypted correctly."""
 
-        user = self._create_user(
+        user = self.create_user(
             db_session, username="user9", password=TEST_PASSWORD, is_active=True
         )
 
@@ -159,7 +159,7 @@ class TestIntegrationSQLAlchemy:
     def test_encrypt_decrypt_bool_false(self, db_session: Session):
         """Test that boolean False is encrypted and decrypted correctly."""
 
-        user = self._create_user(
+        user = self.create_user(
             db_session, username="user10", password=TEST_PASSWORD, is_active=False
         )
 
@@ -169,7 +169,7 @@ class TestIntegrationSQLAlchemy:
     def test_encrypt_decrypt_bool_none(self, db_session: Session):
         """Test that boolean None is handled correctly."""
 
-        user = self._create_user(
+        user = self.create_user(
             db_session, username="user11", password=TEST_PASSWORD, is_active=None
         )
 
@@ -178,7 +178,7 @@ class TestIntegrationSQLAlchemy:
     def test_encrypt_decrypt_float(self, db_session: Session):
         """Test that float fields are encrypted and decrypted correctly."""
 
-        user = self._create_user(
+        user = self.create_user(
             db_session, username="user12", password=TEST_PASSWORD, balance=TEST_BALANCE
         )
 
@@ -188,7 +188,7 @@ class TestIntegrationSQLAlchemy:
     def test_encrypt_decrypt_float_negative(self, db_session: Session):
         """Test that negative float values are handled correctly."""
 
-        user = self._create_user(
+        user = self.create_user(
             db_session, username="user13", password=TEST_PASSWORD, balance=-123.45
         )
 
@@ -197,7 +197,7 @@ class TestIntegrationSQLAlchemy:
     def test_encrypt_decrypt_decimal(self, db_session: Session):
         """Test that Decimal fields are encrypted and decrypted correctly."""
 
-        user = self._create_user(
+        user = self.create_user(
             db_session, username="user14", password=TEST_PASSWORD, salary=TEST_SALARY
         )
 
@@ -209,7 +209,7 @@ class TestIntegrationSQLAlchemy:
 
         high_precision = Decimal("123.456789012345678901234567890")
 
-        user = self._create_user(
+        user = self.create_user(
             db_session, username="user15", password=TEST_PASSWORD, salary=high_precision
         )
 
@@ -218,7 +218,7 @@ class TestIntegrationSQLAlchemy:
     def test_encrypt_decrypt_uuid(self, db_session: Session):
         """Test that UUID fields are encrypted and decrypted correctly."""
 
-        user = self._create_user(
+        user = self.create_user(
             db_session, username="user16", password=TEST_PASSWORD, external_id=TEST_EXTERNAL_ID
         )
 
@@ -228,7 +228,7 @@ class TestIntegrationSQLAlchemy:
     def test_encrypt_decrypt_time(self, db_session: Session):
         """Test that time fields are encrypted and decrypted correctly."""
 
-        user = self._create_user(
+        user = self.create_user(
             db_session, username="user17", password=TEST_PASSWORD, login_time=TEST_LOGIN_TIME
         )
 
@@ -240,7 +240,7 @@ class TestIntegrationSQLAlchemy:
 
         tz_time = time(14, 30, 45, tzinfo=timezone.utc)
 
-        user = self._create_user(
+        user = self.create_user(
             db_session, username="user18", password=TEST_PASSWORD, login_time=tz_time
         )
 
@@ -250,7 +250,7 @@ class TestIntegrationSQLAlchemy:
     def test_encrypt_decrypt_timedelta(self, db_session: Session):
         """Test that timedelta fields are encrypted and decrypted correctly."""
 
-        user = self._create_user(
+        user = self.create_user(
             db_session, username="user19", password=TEST_PASSWORD, session_duration=TEST_SESSION_DURATION
         )
 
@@ -262,7 +262,7 @@ class TestIntegrationSQLAlchemy:
 
         negative_duration = timedelta(days=-1, hours=-5)
 
-        user = self._create_user(
+        user = self.create_user(
             db_session, username="user20", password=TEST_PASSWORD, session_duration=negative_duration
         )
 
@@ -273,7 +273,7 @@ class TestIntegrationSQLAlchemy:
 
         test_tags = ["tag1", "tag2", "tag3"]
 
-        user = self._create_user(
+        user = self.create_user(
             db_session, username="user21", password=TEST_PASSWORD, tags=test_tags
         )
 
@@ -283,7 +283,7 @@ class TestIntegrationSQLAlchemy:
     def test_encrypt_decrypt_array_none(self, db_session: Session):
         """Test that None array values are handled correctly."""
 
-        user = self._create_user(
+        user = self.create_user(
             db_session, username="user22", password=TEST_PASSWORD, tags=None
         )
 
@@ -292,7 +292,7 @@ class TestIntegrationSQLAlchemy:
     def test_encrypt_decrypt_array_empty(self, db_session: Session):
         """Test that empty arrays are handled correctly."""
 
-        user = self._create_user(
+        user = self.create_user(
             db_session, username="user23", password=TEST_PASSWORD, tags=[]
         )
 
@@ -301,7 +301,7 @@ class TestIntegrationSQLAlchemy:
     def test_encrypt_decrypt_array_single_element(self, db_session: Session):
         """Test that single-element arrays are handled correctly."""
 
-        user = self._create_user(
+        user = self.create_user(
             db_session, username="user24", password=TEST_PASSWORD, tags=["only"]
         )
 
@@ -310,7 +310,7 @@ class TestIntegrationSQLAlchemy:
     def test_blind_index_hmac_stored_and_retrieved(self, db_session: Session):
         """Test that HMAC-SHA256 blind index is stored and retrieved correctly."""
 
-        user = self._create_user(
+        user = self.create_user(
             db_session, username="user25", password=TEST_PASSWORD, blind_index_email=TEST_EMAIL
         )
 
@@ -321,7 +321,7 @@ class TestIntegrationSQLAlchemy:
     def test_blind_index_argon2_stored_and_retrieved(self, db_session: Session):
         """Test that Argon2 blind index is stored and retrieved correctly."""
 
-        user = self._create_user(
+        user = self.create_user(
             db_session, username="user26", password=TEST_PASSWORD, blind_index_email_argon2=TEST_EMAIL
         )
 
@@ -332,7 +332,7 @@ class TestIntegrationSQLAlchemy:
     def test_blind_index_none_handling(self, db_session: Session):
         """Test that None blind index values are handled correctly."""
 
-        user = self._create_user(
+        user = self.create_user(
             db_session, username="user27", password=TEST_PASSWORD
         )
 
@@ -344,7 +344,7 @@ class TestIntegrationSQLAlchemy:
 
         unique_email = "blind-index-query-test@example.com"
 
-        self._create_user(
+        self.create_user(
             db_session, username="user28", password=TEST_PASSWORD, blind_index_email=unique_email
         )
 
@@ -360,10 +360,10 @@ class TestIntegrationSQLAlchemy:
     def test_blind_index_different_emails_produce_different_indexes(self, db_session: Session):
         """Test that different emails produce different blind indexes."""
 
-        user1 = self._create_user(
+        user1 = self.create_user(
             db_session, username="user29", password=TEST_PASSWORD, blind_index_email="alice@example.com"
         )
-        user2 = self._create_user(
+        user2 = self.create_user(
             db_session, username="user30", password=TEST_PASSWORD, blind_index_email="bob@example.com"
         )
 
@@ -372,10 +372,10 @@ class TestIntegrationSQLAlchemy:
     def test_blind_index_same_email_produces_same_index(self, db_session: Session):
         """Test that the same email produces the same blind index across rows."""
 
-        user1 = self._create_user(
+        user1 = self.create_user(
             db_session, username="user31", password=TEST_PASSWORD, blind_index_email="same@example.com"
         )
-        user2 = self._create_user(
+        user2 = self.create_user(
             db_session, username="user32", password=TEST_PASSWORD, blind_index_email="same@example.com"
         )
 

--- a/tests/unit/test_async_models.py
+++ b/tests/unit/test_async_models.py
@@ -3,7 +3,7 @@ from typing import Annotated
 
 from pydantic_encryption import BaseModel, Encrypted, Hashed
 from pydantic_encryption.config import settings
-from pydantic_encryption.models.base import _defer_crypto_to_async
+from pydantic_encryption.models.base import defer_crypto_to_async
 from pydantic_encryption.types import (
     BlindIndex,
     BlindIndexMethod,
@@ -13,13 +13,13 @@ from pydantic_encryption.types import (
 )
 
 
-def _construct_without_crypto(cls, **data):
+def construct_without_crypto(cls, **data):
     """Construct a model instance skipping sync crypto (for testing async methods individually)."""
-    token = _defer_crypto_to_async.set(True)
+    token = defer_crypto_to_async.set(True)
     try:
         return cls(**data)
     finally:
-        _defer_crypto_to_async.reset(token)
+        defer_crypto_to_async.reset(token)
 
 
 class TestAsyncInit:
@@ -135,7 +135,7 @@ class TestAsyncEncryptData:
         class _Model(BaseModel):
             secret: Annotated[bytes, Encrypted]
 
-        model = _construct_without_crypto(_Model, secret="plaintext")
+        model = construct_without_crypto(_Model, secret="plaintext")
         assert not isinstance(model.secret, EncryptedValue)
 
         await model.async_encrypt_data()
@@ -147,7 +147,7 @@ class TestAsyncEncryptData:
             field1: Annotated[bytes, Encrypted]
             field2: Annotated[bytes, Encrypted]
 
-        model = _construct_without_crypto(_Model, field1="secret1", field2="secret2")
+        model = construct_without_crypto(_Model, field1="secret1", field2="secret2")
         await model.async_encrypt_data()
 
         assert isinstance(model.field1, EncryptedValue)
@@ -196,7 +196,7 @@ class TestAsyncHashData:
         class _Model(BaseModel):
             password: Annotated[str, Hashed]
 
-        model = _construct_without_crypto(_Model, password="secret123")
+        model = construct_without_crypto(_Model, password="secret123")
         assert not isinstance(model.password, HashedValue)
 
         await model.async_hash_data()
@@ -208,7 +208,7 @@ class TestAsyncHashData:
             password1: Annotated[str, Hashed]
             password2: Annotated[str, Hashed]
 
-        model = _construct_without_crypto(_Model, password1="secret1", password2="secret2")
+        model = construct_without_crypto(_Model, password1="secret1", password2="secret2")
         await model.async_hash_data()
 
         assert isinstance(model.password1, HashedValue)
@@ -224,7 +224,7 @@ class TestAsyncPostInit:
             email: Annotated[bytes, Encrypted]
             password: Annotated[str, Hashed]
 
-        model = _construct_without_crypto(_Model, email="user@example.com", password="secret123")
+        model = construct_without_crypto(_Model, email="user@example.com", password="secret123")
         assert not isinstance(model.email, EncryptedValue)
         assert not isinstance(model.password, HashedValue)
 
@@ -240,7 +240,7 @@ class TestAsyncPostInit:
         class _Model(BaseModel):
             data: Annotated[bytes, Encrypted]
 
-        model = _construct_without_crypto(_Model, data="secret")
+        model = construct_without_crypto(_Model, data="secret")
         await model.async_post_init()
         assert isinstance(model.data, EncryptedValue)
 
@@ -417,7 +417,7 @@ class TestAsyncBlindIndexData:
         class _Model(BaseModel):
             email: Annotated[bytes, BlindIndex(BlindIndexMethod.HMAC_SHA256)]
 
-        model = _construct_without_crypto(_Model, email="test@example.com")
+        model = construct_without_crypto(_Model, email="test@example.com")
         assert not isinstance(model.email, BlindIndexValue)
 
         await model.async_blind_index_data()
@@ -428,7 +428,7 @@ class TestAsyncBlindIndexData:
         class _Model(BaseModel):
             email: Annotated[bytes, BlindIndex(BlindIndexMethod.ARGON2)]
 
-        model = _construct_without_crypto(_Model, email="test@example.com")
+        model = construct_without_crypto(_Model, email="test@example.com")
 
         await model.async_blind_index_data()
         assert isinstance(model.email, BlindIndexValue)
@@ -439,7 +439,7 @@ class TestAsyncBlindIndexData:
             email: Annotated[bytes, BlindIndex(BlindIndexMethod.HMAC_SHA256)]
             phone: Annotated[bytes, BlindIndex(BlindIndexMethod.HMAC_SHA256)]
 
-        model = _construct_without_crypto(_Model, email="test@example.com", phone="1234567890")
+        model = construct_without_crypto(_Model, email="test@example.com", phone="1234567890")
         await model.async_blind_index_data()
 
         assert isinstance(model.email, BlindIndexValue)
@@ -467,7 +467,7 @@ class TestAsyncBlindIndexData:
         class _Model(BaseModel):
             email: Annotated[bytes, BlindIndex(BlindIndexMethod.HMAC_SHA256)]
 
-        model = _construct_without_crypto(_Model, email="test@example.com")
+        model = construct_without_crypto(_Model, email="test@example.com")
         monkeypatch.setattr(settings, "BLIND_INDEX_SECRET_KEY", None)
 
         with pytest.raises(ValueError, match="BLIND_INDEX_SECRET_KEY must be set"):
@@ -480,7 +480,7 @@ class TestAsyncBlindIndexData:
         class _Model(BaseModel):
             email: Annotated[bytes, BlindIndex(BlindIndexMethod.HMAC_SHA256)] | None = None
 
-        model = _construct_without_crypto(_Model)
+        model = construct_without_crypto(_Model)
         monkeypatch.setattr(settings, "BLIND_INDEX_SECRET_KEY", None)
 
         # Should not raise — matches sync behavior
@@ -498,7 +498,7 @@ class TestAsyncEncryptDataErrors:
         class _Model(BaseModel):
             secret: Annotated[bytes, Encrypted]
 
-        model = _construct_without_crypto(_Model, secret="plaintext")
+        model = construct_without_crypto(_Model, secret="plaintext")
         monkeypatch.setattr(settings, "ENCRYPTION_METHOD", None)
 
         with pytest.raises(ValueError, match="ENCRYPTION_METHOD must be set"):
@@ -522,7 +522,7 @@ class TestAsyncEncryptDataErrors:
         class _Model(BaseModel):
             name: str
 
-        model = _construct_without_crypto(_Model, name="john")
+        model = construct_without_crypto(_Model, name="john")
         await model.async_encrypt_data()
         assert model.name == "john"
 
@@ -531,7 +531,7 @@ class TestAsyncEncryptDataErrors:
         class _Model(BaseModel):
             name: str
 
-        model = _construct_without_crypto(_Model, name="john")
+        model = construct_without_crypto(_Model, name="john")
         result = await model.async_decrypt_data()
         assert model.name == "john"
         assert result is model
@@ -541,7 +541,7 @@ class TestAsyncEncryptDataErrors:
         class _Model(BaseModel):
             name: str
 
-        model = _construct_without_crypto(_Model, name="john")
+        model = construct_without_crypto(_Model, name="john")
         await model.async_hash_data()
         assert model.name == "john"
 
@@ -550,6 +550,6 @@ class TestAsyncEncryptDataErrors:
         class _Model(BaseModel):
             name: str
 
-        model = _construct_without_crypto(_Model, name="john")
+        model = construct_without_crypto(_Model, name="john")
         await model.async_blind_index_data()
         assert model.name == "john"

--- a/tests/unit/test_aws_adapter.py
+++ b/tests/unit/test_aws_adapter.py
@@ -18,7 +18,7 @@ from pydantic_encryption.adapters.encryption.aws import (
 from pydantic_encryption.types import EncryptedValue
 
 
-def _reset_adapter_state() -> None:
+def reset_adapter_state() -> None:
     """Clear lazily-initialized KMS clients so each test starts fresh."""
 
     AWSAdapter._sync_client = None
@@ -28,7 +28,7 @@ def _reset_adapter_state() -> None:
     AWSAdapter._async_init_lock = None
 
 
-class _FakeSyncKMSClient:
+class FakeSyncKMSClient:
     """Stand-in for the sync boto3 KMS client; records calls and returns deterministic blobs."""
 
     def __init__(self, plaintext_data_key: bytes) -> None:
@@ -55,7 +55,7 @@ class _FakeSyncKMSClient:
         return {"Plaintext": self.plaintext_data_key}
 
 
-class _FakeAsyncKMSClient:
+class FakeAsyncKMSClient:
     """Stand-in for the aioboto3 KMS client; records calls and returns deterministic blobs."""
 
     def __init__(self, plaintext_data_key: bytes) -> None:
@@ -83,10 +83,10 @@ class _FakeAsyncKMSClient:
 
 
 @pytest.fixture
-def fake_sync_kms(monkeypatch: pytest.MonkeyPatch) -> Iterator[_FakeSyncKMSClient]:
+def fake_sync_kms(monkeypatch: pytest.MonkeyPatch) -> Iterator[FakeSyncKMSClient]:
     """Install a fake sync KMS client and seed AWS settings for the test process."""
 
-    _reset_adapter_state()
+    reset_adapter_state()
 
     from pydantic_encryption.config import settings
 
@@ -97,19 +97,19 @@ def fake_sync_kms(monkeypatch: pytest.MonkeyPatch) -> Iterator[_FakeSyncKMSClien
     monkeypatch.setattr(settings, "AWS_KMS_ACCESS_KEY_ID", "test-access-key")
     monkeypatch.setattr(settings, "AWS_KMS_SECRET_ACCESS_KEY", "test-secret-key")
 
-    client = _FakeSyncKMSClient(plaintext_data_key=b"\x00" * 32)
+    client = FakeSyncKMSClient(plaintext_data_key=b"\x00" * 32)
     AWSAdapter._sync_client = client
 
     yield client
 
-    _reset_adapter_state()
+    reset_adapter_state()
 
 
 @pytest_asyncio.fixture
-async def fake_async_kms(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[_FakeAsyncKMSClient]:
+async def fake_async_kms(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[FakeAsyncKMSClient]:
     """Install a fake async KMS client and seed AWS settings for the test process."""
 
-    _reset_adapter_state()
+    reset_adapter_state()
 
     from pydantic_encryption.config import settings
 
@@ -120,20 +120,20 @@ async def fake_async_kms(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[_Fake
     monkeypatch.setattr(settings, "AWS_KMS_ACCESS_KEY_ID", "test-access-key")
     monkeypatch.setattr(settings, "AWS_KMS_SECRET_ACCESS_KEY", "test-secret-key")
 
-    client = _FakeAsyncKMSClient(plaintext_data_key=b"\x00" * 32)
+    client = FakeAsyncKMSClient(plaintext_data_key=b"\x00" * 32)
     AWSAdapter._async_client = client
     AWSAdapter._async_loop = asyncio.get_running_loop()
 
     yield client
 
-    _reset_adapter_state()
+    reset_adapter_state()
 
 
 class TestAWSAdapterEncrypt:
     """Test that encrypt() wraps a fresh data key under KMS and seals the plaintext with AES-GCM."""
 
     def test_encrypt_returns_encrypted_value_with_known_header(
-        self, fake_sync_kms: _FakeSyncKMSClient
+        self, fake_sync_kms: FakeSyncKMSClient
     ) -> None:
         """Test that encrypt() emits an EncryptedValue starting with the format magic + version."""
 
@@ -146,7 +146,7 @@ class TestAWSAdapterEncrypt:
         assert blob[1] == CIPHERTEXT_VERSION
 
     def test_encrypt_calls_generate_data_key_once_per_call(
-        self, fake_sync_kms: _FakeSyncKMSClient
+        self, fake_sync_kms: FakeSyncKMSClient
     ) -> None:
         """Test that every sync encrypt() call requests a fresh KMS data key."""
 
@@ -157,7 +157,7 @@ class TestAWSAdapterEncrypt:
         for call in fake_sync_kms.generate_calls:
             assert call["KeySpec"] == "AES_256"
 
-    def test_encrypt_encodes_str_input(self, fake_sync_kms: _FakeSyncKMSClient) -> None:
+    def test_encrypt_encodes_str_input(self, fake_sync_kms: FakeSyncKMSClient) -> None:
         """Test that encrypt() encodes a str plaintext to utf-8 before sealing."""
 
         AWSAdapter.encrypt("plain-str")
@@ -165,7 +165,7 @@ class TestAWSAdapterEncrypt:
         assert len(fake_sync_kms.generate_calls) == 1
 
     def test_encrypt_passthrough_for_already_encrypted_value(
-        self, fake_sync_kms: _FakeSyncKMSClient
+        self, fake_sync_kms: FakeSyncKMSClient
     ) -> None:
         """Test that encrypt() returns an existing EncryptedValue unchanged without invoking KMS."""
 
@@ -180,7 +180,7 @@ class TestAWSAdapterEncrypt:
 class TestAWSAdapterDecrypt:
     """Test that decrypt() unwraps the data key via KMS and AES-GCM-decrypts the payload."""
 
-    def test_encrypt_then_decrypt_round_trips(self, fake_sync_kms: _FakeSyncKMSClient) -> None:
+    def test_encrypt_then_decrypt_round_trips(self, fake_sync_kms: FakeSyncKMSClient) -> None:
         """Test that decrypt(encrypt(x)) returns x as a str."""
 
         sealed = AWSAdapter.encrypt("hello world")
@@ -190,7 +190,7 @@ class TestAWSAdapterDecrypt:
         assert result == "hello world"
         assert len(fake_sync_kms.decrypt_calls) == 1
 
-    def test_decrypt_each_call_invokes_kms(self, fake_sync_kms: _FakeSyncKMSClient) -> None:
+    def test_decrypt_each_call_invokes_kms(self, fake_sync_kms: FakeSyncKMSClient) -> None:
         """Test that every decrypt() call routes through the KMS client (no plaintext cache)."""
 
         sealed_one = AWSAdapter.encrypt("first")
@@ -203,7 +203,7 @@ class TestAWSAdapterDecrypt:
 
         assert len(fake_sync_kms.decrypt_calls) == 3
 
-    def test_decrypt_rejects_unrecognized_format(self, fake_sync_kms: _FakeSyncKMSClient) -> None:
+    def test_decrypt_rejects_unrecognized_format(self, fake_sync_kms: FakeSyncKMSClient) -> None:
         """Test that decrypt() raises ValueError when the magic byte does not match."""
 
         bogus = b"\x01" + b"\x00" * 32
@@ -211,7 +211,7 @@ class TestAWSAdapterDecrypt:
         with pytest.raises(ValueError, match="Unrecognized ciphertext format"):
             AWSAdapter.decrypt(bogus)
 
-    def test_decrypt_rejects_unsupported_version(self, fake_sync_kms: _FakeSyncKMSClient) -> None:
+    def test_decrypt_rejects_unsupported_version(self, fake_sync_kms: FakeSyncKMSClient) -> None:
         """Test that decrypt() raises ValueError when the version byte is not supported."""
 
         unsupported = bytes([CIPHERTEXT_MAGIC, 0x99]) + b"\x00" * (HEADER_LENGTH + NONCE_LENGTH)
@@ -221,7 +221,7 @@ class TestAWSAdapterDecrypt:
 
     def test_decrypt_passes_decrypt_arn_to_kms_when_configured(
         self,
-        fake_sync_kms: _FakeSyncKMSClient,
+        fake_sync_kms: FakeSyncKMSClient,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test that decrypt() includes the configured KeyId when AWS_KMS_DECRYPT_KEY_ARN is set."""
@@ -241,7 +241,7 @@ class TestAWSAdapterAsync:
 
     @pytest.mark.asyncio
     async def test_async_encrypt_then_async_decrypt_round_trips(
-        self, fake_async_kms: _FakeAsyncKMSClient
+        self, fake_async_kms: FakeAsyncKMSClient
     ) -> None:
         """Test that async_decrypt(async_encrypt(x)) returns x as a str via the async client."""
 
@@ -255,7 +255,7 @@ class TestAWSAdapterAsync:
 
     @pytest.mark.asyncio
     async def test_async_encrypt_passthrough_for_already_encrypted_value(
-        self, fake_async_kms: _FakeAsyncKMSClient
+        self, fake_async_kms: FakeAsyncKMSClient
     ) -> None:
         """Test that async_encrypt() returns an existing EncryptedValue without invoking KMS."""
 
@@ -269,7 +269,7 @@ class TestAWSAdapterAsync:
     @pytest.mark.asyncio
     async def test_async_decrypt_passes_decrypt_arn_when_configured(
         self,
-        fake_async_kms: _FakeAsyncKMSClient,
+        fake_async_kms: FakeAsyncKMSClient,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test that async_decrypt() includes the configured KeyId when AWS_KMS_DECRYPT_KEY_ARN is set."""
@@ -292,7 +292,7 @@ class TestAWSAdapterValidation:
     ) -> None:
         """Test that the lazy KMS client builder rejects unset AWS_KMS settings at use time."""
 
-        _reset_adapter_state()
+        reset_adapter_state()
 
         from pydantic_encryption.config import settings
 
@@ -310,7 +310,7 @@ class TestAWSAdapterValidation:
             AWSAdapter.encrypt(b"payload")
 
     def test_decrypt_accepts_str_ciphertext_via_latin1(
-        self, fake_sync_kms: _FakeSyncKMSClient
+        self, fake_sync_kms: FakeSyncKMSClient
     ) -> None:
         """Test that decrypt() coerces a str ciphertext to bytes 1:1 (latin-1) for the EncryptionAdapter contract."""
 
@@ -322,13 +322,13 @@ class TestAWSAdapterValidation:
 
         assert result == "hello world"
 
-    def test_decrypt_rejects_truncated_ciphertext(self, fake_sync_kms: _FakeSyncKMSClient) -> None:
+    def test_decrypt_rejects_truncated_ciphertext(self, fake_sync_kms: FakeSyncKMSClient) -> None:
         """Test that decrypt() raises when the input is shorter than the envelope header."""
 
         with pytest.raises(ValueError, match="too short"):
             AWSAdapter.decrypt(b"\xc0\x01")
 
-    def test_decrypt_rejects_truncated_payload(self, fake_sync_kms: _FakeSyncKMSClient) -> None:
+    def test_decrypt_rejects_truncated_payload(self, fake_sync_kms: FakeSyncKMSClient) -> None:
         """Test that decrypt() raises when the header announces more bytes than the blob carries."""
 
         import struct
@@ -354,7 +354,7 @@ class TestAWSAdapterLazyInit:
     ) -> None:
         """Test that the first call to ``encrypt()`` builds a boto3 KMS client and caches it."""
 
-        _reset_adapter_state()
+        reset_adapter_state()
 
         from pydantic_encryption.config import settings
 
@@ -369,7 +369,7 @@ class TestAWSAdapterLazyInit:
 
         def fake_boto3_client(service: str, **kwargs: Any) -> Any:
             captured_kwargs.append({"service": service, **kwargs})
-            return _FakeSyncKMSClient(plaintext_data_key=b"\x00" * 32)
+            return FakeSyncKMSClient(plaintext_data_key=b"\x00" * 32)
 
         monkeypatch.setattr("pydantic_encryption.adapters.encryption.aws.boto3.client", fake_boto3_client)
 
@@ -384,7 +384,7 @@ class TestAWSAdapterLazyInit:
 
         assert len(captured_kwargs) == 1
 
-        _reset_adapter_state()
+        reset_adapter_state()
 
     @pytest.mark.asyncio
     async def test_async_kms_opens_aioboto3_client_on_first_use(
@@ -392,7 +392,7 @@ class TestAWSAdapterLazyInit:
     ) -> None:
         """Test that the first ``async_encrypt()`` opens an aioboto3 KMS client and caches it for the loop."""
 
-        _reset_adapter_state()
+        reset_adapter_state()
 
         from pydantic_encryption.config import settings
 
@@ -403,14 +403,14 @@ class TestAWSAdapterLazyInit:
         monkeypatch.setattr(settings, "AWS_KMS_ACCESS_KEY_ID", "test-access")
         monkeypatch.setattr(settings, "AWS_KMS_SECRET_ACCESS_KEY", "test-secret")
 
-        opened_clients: list[_FakeAsyncKMSClient] = []
+        opened_clients: list[FakeAsyncKMSClient] = []
         session_kwargs: list[dict[str, Any]] = []
 
         class _FakeClientCtx:
-            def __init__(self, client: _FakeAsyncKMSClient) -> None:
+            def __init__(self, client: FakeAsyncKMSClient) -> None:
                 self._client = client
 
-            async def __aenter__(self) -> _FakeAsyncKMSClient:
+            async def __aenter__(self) -> FakeAsyncKMSClient:
                 opened_clients.append(self._client)
                 return self._client
 
@@ -423,7 +423,7 @@ class TestAWSAdapterLazyInit:
 
             def client(self, service: str, **client_kwargs: Any) -> _FakeClientCtx:
                 assert service == "kms"
-                return _FakeClientCtx(_FakeAsyncKMSClient(plaintext_data_key=b"\x00" * 32))
+                return _FakeClientCtx(FakeAsyncKMSClient(plaintext_data_key=b"\x00" * 32))
 
         monkeypatch.setattr(
             "pydantic_encryption.adapters.encryption.aws.aioboto3.Session", _FakeAioSession
@@ -440,7 +440,7 @@ class TestAWSAdapterLazyInit:
 
         assert len(opened_clients) == 1
 
-        _reset_adapter_state()
+        reset_adapter_state()
 
     @pytest.mark.asyncio
     async def test_async_kms_coalesces_concurrent_first_callers(
@@ -448,7 +448,7 @@ class TestAWSAdapterLazyInit:
     ) -> None:
         """Test that concurrent first-time async_encrypt calls open the aioboto3 client exactly once."""
 
-        _reset_adapter_state()
+        reset_adapter_state()
 
         from pydantic_encryption.config import settings
 
@@ -459,13 +459,13 @@ class TestAWSAdapterLazyInit:
         monkeypatch.setattr(settings, "AWS_KMS_ACCESS_KEY_ID", "test-access")
         monkeypatch.setattr(settings, "AWS_KMS_SECRET_ACCESS_KEY", "test-secret")
 
-        opened_clients: list[_FakeAsyncKMSClient] = []
+        opened_clients: list[FakeAsyncKMSClient] = []
 
         class _FakeClientCtx:
-            def __init__(self, client: _FakeAsyncKMSClient) -> None:
+            def __init__(self, client: FakeAsyncKMSClient) -> None:
                 self._client = client
 
-            async def __aenter__(self) -> _FakeAsyncKMSClient:
+            async def __aenter__(self) -> FakeAsyncKMSClient:
                 await asyncio.sleep(0)
                 opened_clients.append(self._client)
                 return self._client
@@ -478,7 +478,7 @@ class TestAWSAdapterLazyInit:
                 pass
 
             def client(self, service: str, **client_kwargs: Any) -> _FakeClientCtx:
-                return _FakeClientCtx(_FakeAsyncKMSClient(plaintext_data_key=b"\x00" * 32))
+                return _FakeClientCtx(FakeAsyncKMSClient(plaintext_data_key=b"\x00" * 32))
 
         monkeypatch.setattr(
             "pydantic_encryption.adapters.encryption.aws.aioboto3.Session", _FakeAioSession
@@ -492,7 +492,7 @@ class TestAWSAdapterLazyInit:
 
         assert len(opened_clients) == 1
 
-        _reset_adapter_state()
+        reset_adapter_state()
 
     @pytest.mark.asyncio
     async def test_aclose_async_kms_exits_the_context_manager(
@@ -500,7 +500,7 @@ class TestAWSAdapterLazyInit:
     ) -> None:
         """Test that aclose_async_kms() drives __aexit__ on the cached aioboto3 client context."""
 
-        _reset_adapter_state()
+        reset_adapter_state()
 
         from pydantic_encryption.config import settings
 
@@ -514,10 +514,10 @@ class TestAWSAdapterLazyInit:
         exit_calls: list[tuple[Any, ...]] = []
 
         class _FakeClientCtx:
-            def __init__(self, client: _FakeAsyncKMSClient) -> None:
+            def __init__(self, client: FakeAsyncKMSClient) -> None:
                 self._client = client
 
-            async def __aenter__(self) -> _FakeAsyncKMSClient:
+            async def __aenter__(self) -> FakeAsyncKMSClient:
                 return self._client
 
             async def __aexit__(self, *exc: Any) -> None:
@@ -528,7 +528,7 @@ class TestAWSAdapterLazyInit:
                 pass
 
             def client(self, service: str, **client_kwargs: Any) -> _FakeClientCtx:
-                return _FakeClientCtx(_FakeAsyncKMSClient(plaintext_data_key=b"\x00" * 32))
+                return _FakeClientCtx(FakeAsyncKMSClient(plaintext_data_key=b"\x00" * 32))
 
         monkeypatch.setattr(
             "pydantic_encryption.adapters.encryption.aws.aioboto3.Session", _FakeAioSession
@@ -549,4 +549,4 @@ class TestAWSAdapterLazyInit:
 
         assert exit_calls == [(None, None, None)]
 
-        _reset_adapter_state()
+        reset_adapter_state()

--- a/tests/unit/test_registry.py
+++ b/tests/unit/test_registry.py
@@ -1,0 +1,151 @@
+import pytest
+
+from pydantic_encryption.adapters import registry
+from pydantic_encryption.adapters.encryption.fernet import FernetAdapter
+from pydantic_encryption.types import BlindIndexMethod, EncryptionMethod
+
+
+class FakeMethod:
+    """Stand-in registry key that is never pre-populated by the package."""
+
+    def __repr__(self) -> str:
+        return "FakeMethod()"
+
+
+class TestGetEncryptionBackend:
+    """Test ``get_encryption_backend`` resolution and lazy loading."""
+
+    def test_returns_eagerly_registered_backend(self):
+        """Test that an eagerly registered backend is returned without locking."""
+
+        assert registry.get_encryption_backend(EncryptionMethod.FERNET) is FernetAdapter
+
+    def test_lazy_factory_is_invoked_and_cached(self):
+        """Test that a lazy factory is invoked under the lock, cached, and removed from factories."""
+
+        method = FakeMethod()
+        calls: list[int] = []
+
+        def factory() -> type:
+            calls.append(1)
+            return FernetAdapter
+
+        registry.register_encryption_backend_lazy(method, factory)
+
+        try:
+            assert method not in registry.encryption_backends
+            assert registry.get_encryption_backend(method) is FernetAdapter
+            assert registry.encryption_backends[method] is FernetAdapter
+            assert method not in registry.encryption_factories
+
+            assert registry.get_encryption_backend(method) is FernetAdapter
+            assert calls == [1]
+        finally:
+            registry.encryption_backends.pop(method, None)
+            registry.encryption_factories.pop(method, None)
+
+    def test_cached_backend_short_circuits_inside_lock(self):
+        """Test that a backend cached under the lock is returned without re-invoking the factory."""
+
+        method = FakeMethod()
+
+        def factory() -> type:
+            raise AssertionError("factory must not be called when backend is cached")
+
+        registry.register_encryption_backend_lazy(method, factory)
+        registry.encryption_backends[method] = FernetAdapter
+
+        try:
+            assert registry.get_encryption_backend(method) is FernetAdapter
+        finally:
+            registry.encryption_backends.pop(method, None)
+            registry.encryption_factories.pop(method, None)
+
+    def test_inside_lock_double_check_returns_concurrently_populated_backend(self, monkeypatch):
+        """Test that the inside-lock double-check returns a backend populated after the outer check."""
+
+        method = FakeMethod()
+
+        def factory() -> type:
+            raise AssertionError("factory must not be called once the backend is populated")
+
+        registry.register_encryption_backend_lazy(method, factory)
+
+        class PopulateOnLock:
+            """Lock stand-in that simulates another thread caching the backend before lock entry."""
+
+            def __enter__(self) -> "PopulateOnLock":
+                registry.encryption_backends[method] = FernetAdapter
+
+                return self
+
+            def __exit__(self, *exc_info) -> None:
+                return None
+
+        monkeypatch.setattr(registry, "registry_lock", PopulateOnLock())
+
+        try:
+            assert method not in registry.encryption_backends
+
+            assert registry.get_encryption_backend(method) is FernetAdapter
+        finally:
+            registry.encryption_backends.pop(method, None)
+            registry.encryption_factories.pop(method, None)
+
+    def test_unknown_method_raises_value_error(self):
+        """Test that an unregistered method raises a ValueError."""
+
+        method = FakeMethod()
+
+        with pytest.raises(ValueError, match="No encryption backend registered"):
+            registry.get_encryption_backend(method)
+
+    def test_failing_factory_stays_retryable(self):
+        """Test that a failing factory is not removed so it surfaces the real error on retry."""
+
+        method = FakeMethod()
+
+        def factory() -> type:
+            raise ImportError("optional dependency missing")
+
+        registry.register_encryption_backend_lazy(method, factory)
+
+        try:
+            with pytest.raises(ImportError, match="optional dependency missing"):
+                registry.get_encryption_backend(method)
+
+            assert method in registry.encryption_factories
+            assert method not in registry.encryption_backends
+        finally:
+            registry.encryption_backends.pop(method, None)
+            registry.encryption_factories.pop(method, None)
+
+
+class TestGetBlindIndexBackend:
+    """Test ``get_blind_index_backend`` resolution."""
+
+    def test_returns_registered_backend(self):
+        """Test that a registered blind index backend is returned."""
+
+        from pydantic_encryption.adapters.blind_index.hmac_sha256 import HMACSHA256Adapter
+
+        assert registry.get_blind_index_backend(BlindIndexMethod.HMAC_SHA256) is HMACSHA256Adapter
+
+    def test_unknown_method_raises_value_error(self):
+        """Test that an unregistered blind index method raises a ValueError."""
+
+        method = FakeMethod()
+
+        with pytest.raises(ValueError, match="No blind index backend registered"):
+            registry.get_blind_index_backend(method)
+
+
+class TestLoadAwsAdapter:
+    """Test the lazily registered AWS adapter factory."""
+
+    def test_load_aws_adapter_imports_adapter(self):
+        """Test that the AWS factory imports and returns the AWSAdapter class."""
+
+        from pydantic_encryption.adapters.encryption.aws import AWSAdapter
+
+        assert registry.load_aws_adapter() is AWSAdapter

--- a/tests/unit/test_sqlalchemy/test_auto_decrypt_session.py
+++ b/tests/unit/test_sqlalchemy/test_auto_decrypt_session.py
@@ -17,11 +17,11 @@ from pydantic_encryption.integrations.sqlalchemy.encryption import SQLAlchemyEnc
 from pydantic_encryption.types import EncryptedValue
 
 
-class _AutoDecryptBase(DeclarativeBase):
+class AutoDecryptBase(DeclarativeBase):
     """Isolated declarative base for on-access decrypt session-level tests."""
 
 
-class _AutoDecryptUser(_AutoDecryptBase, DeferredDecryptMixin):
+class AutoDecryptUser(AutoDecryptBase, DeferredDecryptMixin):
     """Mapped class with a string-typed deferred encrypted column."""
 
     __tablename__ = "_auto_decrypt_user"
@@ -32,7 +32,7 @@ class _AutoDecryptUser(_AutoDecryptBase, DeferredDecryptMixin):
     )
 
 
-class _AutoDecryptBlob(_AutoDecryptBase, DeferredDecryptMixin):
+class AutoDecryptBlob(AutoDecryptBase, DeferredDecryptMixin):
     """Mapped class with a bytes-typed deferred encrypted column to test idempotency."""
 
     __tablename__ = "_auto_decrypt_blob"
@@ -43,16 +43,16 @@ class _AutoDecryptBlob(_AutoDecryptBase, DeferredDecryptMixin):
     )
 
 
-def _encrypt(value: Any) -> bytes:
+def encrypt_value(value: Any) -> bytes:
     """Encrypt a value via the SQLAlchemyEncryptedValue write path."""
 
     return SQLAlchemyEncryptedValue().process_bind_param(value, None)
 
 
-def _wrap(value: Any) -> EncryptedValue:
+def wrap_encrypted(value: Any) -> EncryptedValue:
     """Wrap ciphertext in EncryptedValue the way process_result_value does on read."""
 
-    return EncryptedValue(_encrypt(value))
+    return EncryptedValue(encrypt_value(value))
 
 
 class TestOnOrmLoadListener:
@@ -65,47 +65,47 @@ class TestOnOrmLoadListener:
     def test_collects_into_session_bucket(self):
         session = SimpleNamespace(info={})
         context = SimpleNamespace(session=session)
-        instance = _AutoDecryptUser(id=1)
+        instance = AutoDecryptUser(id=1)
 
         on_orm_load(instance, context)
 
         bucket = session.info[PENDING_DECRYPT_KEY]
-        assert instance in bucket[_AutoDecryptUser]
+        assert instance in bucket[AutoDecryptUser]
 
     def test_noop_when_session_is_none(self):
         context = SimpleNamespace(session=None)
 
-        on_orm_load(_AutoDecryptUser(id=1), context)
+        on_orm_load(AutoDecryptUser(id=1), context)
 
     def test_noop_when_context_is_none(self):
-        on_orm_load(_AutoDecryptUser(id=1), None)
+        on_orm_load(AutoDecryptUser(id=1), None)
 
     def test_groups_by_class(self):
         session = SimpleNamespace(info={})
         context = SimpleNamespace(session=session)
-        user_a = _AutoDecryptUser(id=1)
-        user_b = _AutoDecryptUser(id=2)
-        blob = _AutoDecryptBlob(id=1)
+        user_a = AutoDecryptUser(id=1)
+        user_b = AutoDecryptUser(id=2)
+        blob = AutoDecryptBlob(id=1)
 
         on_orm_load(user_a, context)
         on_orm_load(user_b, context)
         on_orm_load(blob, context)
 
         bucket = session.info[PENDING_DECRYPT_KEY]
-        assert set(bucket[_AutoDecryptUser]) == {user_a, user_b}
-        assert set(bucket[_AutoDecryptBlob]) == {blob}
+        assert set(bucket[AutoDecryptUser]) == {user_a, user_b}
+        assert set(bucket[AutoDecryptBlob]) == {blob}
 
     def test_refresh_dedups_same_instance(self):
         session = SimpleNamespace(info={})
         context = SimpleNamespace(session=session)
-        instance = _AutoDecryptUser(id=1)
+        instance = AutoDecryptUser(id=1)
 
         on_orm_load(instance, context)
         on_orm_load(instance, context)
         on_orm_load(instance, context)
 
         bucket = session.info[PENDING_DECRYPT_KEY]
-        assert len(bucket[_AutoDecryptUser]) == 1
+        assert len(bucket[AutoDecryptUser]) == 1
 
 
 class TestDecryptPendingFields:
@@ -113,12 +113,12 @@ class TestDecryptPendingFields:
 
     def test_drain_decrypts_every_pending_class(self):
         session = SimpleNamespace(info={})
-        user = _AutoDecryptUser(id=1, email=_wrap("a@x.com"))
-        blob = _AutoDecryptBlob(id=1, payload=_wrap(b"shh"))
+        user = AutoDecryptUser(id=1, email=wrap_encrypted("a@x.com"))
+        blob = AutoDecryptBlob(id=1, payload=wrap_encrypted(b"shh"))
 
         bucket: dict[type, WeakSet] = defaultdict(WeakSet)
-        bucket[_AutoDecryptUser].add(user)
-        bucket[_AutoDecryptBlob].add(blob)
+        bucket[AutoDecryptUser].add(user)
+        bucket[AutoDecryptBlob].add(blob)
         session.info[PENDING_DECRYPT_KEY] = bucket
 
         asyncio.run(decrypt_pending_fields(session))
@@ -143,9 +143,9 @@ class TestBytesColumnIdempotency:
         configure_mappers()
 
     def test_collect_skips_already_decrypted_bytes_plaintext(self):
-        blob = _AutoDecryptBlob(id=1, payload=_wrap(b"shh"))
+        blob = AutoDecryptBlob(id=1, payload=wrap_encrypted(b"shh"))
 
-        asyncio.run(_AutoDecryptBlob.decrypt_many([blob]))
+        asyncio.run(AutoDecryptBlob.decrypt_many([blob]))
 
         assert sa_inspect(blob).dict["payload"] == b"shh"
         assert not isinstance(sa_inspect(blob).dict["payload"], EncryptedValue)
@@ -166,12 +166,12 @@ class TestDrainParallelism:
 
     def test_drain_dispatches_cells_across_classes_in_parallel(self):
         session = SimpleNamespace(info={})
-        user = _AutoDecryptUser(id=1, email=_wrap("a@x.com"))
-        blob = _AutoDecryptBlob(id=1, payload=_wrap(b"shh"))
+        user = AutoDecryptUser(id=1, email=wrap_encrypted("a@x.com"))
+        blob = AutoDecryptBlob(id=1, payload=wrap_encrypted(b"shh"))
 
         bucket: dict[type, WeakSet] = defaultdict(WeakSet)
-        bucket[_AutoDecryptUser].add(user)
-        bucket[_AutoDecryptBlob].add(blob)
+        bucket[AutoDecryptUser].add(user)
+        bucket[AutoDecryptBlob].add(blob)
         session.info[PENDING_DECRYPT_KEY] = bucket
 
         live_overlap = 0
@@ -207,13 +207,13 @@ class TestNoDirtyAfterDecrypt:
         configure_mappers()
 
     def test_decrypt_many_does_not_mark_column_dirty(self):
-        user = _AutoDecryptUser(id=1, email=_wrap("a@x.com"))
+        user = AutoDecryptUser(id=1, email=wrap_encrypted("a@x.com"))
         state = sa_inspect(user)
         state._commit_all(state.dict)
 
         assert "email" not in state.committed_state
 
-        asyncio.run(_AutoDecryptUser.decrypt_many([user]))
+        asyncio.run(AutoDecryptUser.decrypt_many([user]))
 
         assert sa_inspect(user).dict["email"] == "a@x.com"
         assert "email" not in state.committed_state

--- a/tests/unit/test_sqlalchemy/test_bulk.py
+++ b/tests/unit/test_sqlalchemy/test_bulk.py
@@ -22,11 +22,11 @@ from pydantic_encryption.integrations.sqlalchemy.encryption import (
 from pydantic_encryption.types import EncryptedValue
 
 
-class _DeferBase(DeclarativeBase):
+class DeferBase(DeclarativeBase):
     """Isolated declarative base for mixin auto-defer tests."""
 
 
-class _DeferMixed(_DeferBase, DeferredDecryptMixin):
+class DeferMixed(DeferBase, DeferredDecryptMixin):
     """Mapped class that inherits DeferredDecryptMixin."""
 
     __tablename__ = "_defer_mixed"
@@ -37,7 +37,7 @@ class _DeferMixed(_DeferBase, DeferredDecryptMixin):
     )
 
 
-class _DeferPlain(_DeferBase):
+class DeferPlain(DeferBase):
     """Mapped class that does NOT inherit DeferredDecryptMixin."""
 
     __tablename__ = "_defer_plain"
@@ -56,7 +56,7 @@ class TestDeferDecrypt:
         configure_mappers()
 
     def test_mixin_column_returns_encrypted_value(self):
-        column_type = _DeferMixed.__table__.c.secret.type
+        column_type = DeferMixed.__table__.c.secret.type
         assert column_type._deferred is True
 
         ciphertext = column_type.process_bind_param("hello", None)
@@ -67,11 +67,11 @@ class TestDeferDecrypt:
         assert result != "hello"
 
     def test_mixin_column_none_passthrough(self):
-        column_type = _DeferMixed.__table__.c.secret.type
+        column_type = DeferMixed.__table__.c.secret.type
         assert column_type.process_result_value(None, None) is None
 
     def test_plain_column_returns_plaintext(self):
-        column_type = _DeferPlain.__table__.c.secret.type
+        column_type = DeferPlain.__table__.c.secret.type
         assert column_type._deferred is False
 
         ciphertext = column_type.process_bind_param("hello", None)
@@ -82,15 +82,15 @@ class TestDeferDecrypt:
 class TestDecryptRows:
     """Test the decrypt_rows bulk helper."""
 
-    def _make_ciphertext(self, value):
+    def make_ciphertext(self, value):
         return SQLAlchemyEncryptedValue().process_bind_param(value, None)
 
     def test_decrypt_rows_fernet(self):
         # Build 3 fake rows with 2 encrypted columns each.
         rows = [
             SimpleNamespace(
-                email=EncryptedValue(self._make_ciphertext(f"user{i}@example.com")),
-                secret=EncryptedValue(self._make_ciphertext(f"secret-{i}")),
+                email=EncryptedValue(self.make_ciphertext(f"user{i}@example.com")),
+                secret=EncryptedValue(self.make_ciphertext(f"secret-{i}")),
             )
             for i in range(3)
         ]
@@ -107,8 +107,8 @@ class TestDecryptRows:
 
     def test_decrypt_rows_skips_none_cells(self):
         rows = [
-            SimpleNamespace(email=EncryptedValue(self._make_ciphertext("a@x.com")), secret=None),
-            SimpleNamespace(email=None, secret=EncryptedValue(self._make_ciphertext("s1"))),
+            SimpleNamespace(email=EncryptedValue(self.make_ciphertext("a@x.com")), secret=None),
+            SimpleNamespace(email=None, secret=EncryptedValue(self.make_ciphertext("s1"))),
         ]
 
         asyncio.run(decrypt_rows(rows, "email", "secret"))
@@ -119,21 +119,21 @@ class TestDecryptRows:
         assert rows[1].secret == "s1"
 
 
-class _BulkBase(DeclarativeBase):
+class BulkBase(DeclarativeBase):
     """Isolated declarative base for DeferredDecryptMixin tests."""
 
 
-class _BulkOrg(_BulkBase, DeferredDecryptMixin):
+class BulkOrg(BulkBase, DeferredDecryptMixin):
     """Test ORM parent with no encrypted columns."""
 
     __tablename__ = "_bulk_test_org"
 
     id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str | None] = mapped_column(nullable=True, default=None)
-    contractors: Mapped[list["_BulkContractor"]] = relationship(back_populates="org")
+    contractors: Mapped[list["BulkContractor"]] = relationship(back_populates="org")
 
 
-class _BulkContractor(_BulkBase, DeferredDecryptMixin):
+class BulkContractor(BulkBase, DeferredDecryptMixin):
     """Test ORM child with deferred encrypted columns."""
 
     __tablename__ = "_bulk_test_contractor"
@@ -146,10 +146,10 @@ class _BulkContractor(_BulkBase, DeferredDecryptMixin):
     last_name: Mapped[str | None] = mapped_column(
         SQLAlchemyEncryptedValue(), nullable=True, default=None
     )
-    org: Mapped["_BulkOrg | None"] = relationship(back_populates="contractors")
+    org: Mapped["BulkOrg | None"] = relationship(back_populates="contractors")
 
 
-def _encrypt_deferred(value: str) -> bytes:
+def encrypt_deferred(value: str) -> bytes:
     """Encrypt a value using SQLAlchemyEncryptedValue on the write path."""
 
     return SQLAlchemyEncryptedValue().process_bind_param(value, None)
@@ -159,14 +159,14 @@ class TestDeferredDecryptMixin:
     """Test the DeferredDecryptMixin decrypt() and decrypt_many() helpers."""
 
     def test_decrypt_many_none_and_empty(self):
-        asyncio.run(_BulkContractor.decrypt_many(None))
-        asyncio.run(_BulkContractor.decrypt_many([]))
+        asyncio.run(BulkContractor.decrypt_many(None))
+        asyncio.run(BulkContractor.decrypt_many([]))
 
     def test_instance_decrypt(self):
-        contractor = _BulkContractor(
+        contractor = BulkContractor(
             id=1,
-            first_name=_encrypt_deferred("Alice"),
-            last_name=_encrypt_deferred("Smith"),
+            first_name=encrypt_deferred("Alice"),
+            last_name=encrypt_deferred("Smith"),
         )
 
         returned = asyncio.run(contractor.decrypt())
@@ -177,15 +177,15 @@ class TestDeferredDecryptMixin:
 
     def test_decrypt_many(self):
         contractors = [
-            _BulkContractor(
+            BulkContractor(
                 id=i,
-                first_name=_encrypt_deferred(f"First{i}"),
-                last_name=_encrypt_deferred(f"Last{i}"),
+                first_name=encrypt_deferred(f"First{i}"),
+                last_name=encrypt_deferred(f"Last{i}"),
             )
             for i in range(3)
         ]
 
-        asyncio.run(_BulkContractor.decrypt_many(contractors))
+        asyncio.run(BulkContractor.decrypt_many(contractors))
 
         for i, contractor in enumerate(contractors):
             assert contractor.first_name == f"First{i}"
@@ -193,22 +193,22 @@ class TestDeferredDecryptMixin:
 
     def test_decrypt_many_accepts_generator(self):
         contractors = [
-            _BulkContractor(
+            BulkContractor(
                 id=i,
-                first_name=_encrypt_deferred(f"Gen{i}"),
-                last_name=_encrypt_deferred(f"Last{i}"),
+                first_name=encrypt_deferred(f"Gen{i}"),
+                last_name=encrypt_deferred(f"Last{i}"),
             )
             for i in range(3)
         ]
 
-        asyncio.run(_BulkContractor.decrypt_many(c for c in contractors))
+        asyncio.run(BulkContractor.decrypt_many(c for c in contractors))
 
         for i, contractor in enumerate(contractors):
             assert contractor.first_name == f"Gen{i}"
             assert contractor.last_name == f"Last{i}"
 
     def test_none_column_values_skipped(self):
-        contractor = _BulkContractor(id=1, first_name=_encrypt_deferred("Alice"), last_name=None)
+        contractor = BulkContractor(id=1, first_name=encrypt_deferred("Alice"), last_name=None)
 
         asyncio.run(contractor.decrypt())
 
@@ -216,8 +216,8 @@ class TestDeferredDecryptMixin:
         assert contractor.last_name is None
 
     def test_walks_loaded_relationships(self):
-        org = _BulkOrg(id=1, name="Acme")
-        contractor = _BulkContractor(id=1, first_name=_encrypt_deferred("Alice"), last_name=None)
+        org = BulkOrg(id=1, name="Acme")
+        contractor = BulkContractor(id=1, first_name=encrypt_deferred("Alice"), last_name=None)
         org.contractors = [contractor]
 
         asyncio.run(org.decrypt())
@@ -225,7 +225,7 @@ class TestDeferredDecryptMixin:
         assert contractor.first_name == "Alice"
 
     def test_all_columns_none(self):
-        contractor = _BulkContractor(id=1, first_name=None, last_name=None)
+        contractor = BulkContractor(id=1, first_name=None, last_name=None)
 
         asyncio.run(contractor.decrypt())
 
@@ -236,11 +236,11 @@ class TestDeferredDecryptMixin:
 class TestDecryptValues:
     """Test the decrypt_values bulk helper for flat ciphertext iterables."""
 
-    def _make_ciphertext(self, value: str) -> bytes:
+    def make_ciphertext(self, value: str) -> bytes:
         return SQLAlchemyEncryptedValue().process_bind_param(value, None)
 
     def test_decrypts_list_of_ciphertexts(self):
-        values = [self._make_ciphertext(f"user-{i}") for i in range(3)]
+        values = [self.make_ciphertext(f"user-{i}") for i in range(3)]
 
         result = asyncio.run(decrypt_values(values))
 
@@ -248,9 +248,9 @@ class TestDecryptValues:
 
     def test_preserves_none_positions(self):
         values = [
-            self._make_ciphertext("a"),
+            self.make_ciphertext("a"),
             None,
-            self._make_ciphertext("b"),
+            self.make_ciphertext("b"),
             None,
         ]
 
@@ -262,7 +262,7 @@ class TestDecryptValues:
         assert asyncio.run(decrypt_values([])) == []
 
     def test_passes_through_non_bytes_cells(self):
-        values = [self._make_ciphertext("a"), 42, "plain", None]
+        values = [self.make_ciphertext("a"), 42, "plain", None]
 
         result = asyncio.run(decrypt_values(values))
 

--- a/tests/unit/test_sqlalchemy/test_encryption.py
+++ b/tests/unit/test_sqlalchemy/test_encryption.py
@@ -317,8 +317,8 @@ class TestEncryptionIdempotency:
         self.type_adapter = SQLAlchemyEncryptedValue()
 
     def test_encrypt_cell_already_encrypted_returns_same(self):
-        encrypted = self.type_adapter._encrypt_cell("hello")
-        double_encrypted = self.type_adapter._encrypt_cell(encrypted)
+        encrypted = self.type_adapter.encrypt_cell("hello")
+        double_encrypted = self.type_adapter.encrypt_cell(encrypted)
         assert encrypted == double_encrypted
 
     def test_process_bind_param_already_encrypted_returns_same(self):

--- a/tests/unit/test_sqlalchemy/test_encryption.py
+++ b/tests/unit/test_sqlalchemy/test_encryption.py
@@ -5,7 +5,12 @@ from uuid import UUID
 
 import pytest
 
-from pydantic_encryption.integrations.sqlalchemy.encryption import SQLAlchemyEncryptedValue
+from pydantic_encryption.adapters.encryption.fernet import FernetAdapter
+from pydantic_encryption.config import settings
+from pydantic_encryption.integrations.sqlalchemy.encryption import (
+    SQLAlchemyEncryptedValue,
+    SQLAlchemyPGEncryptedArray,
+)
 from pydantic_encryption.integrations.sqlalchemy.serialization import (
     TypePrefix,
     decode_value,
@@ -334,3 +339,64 @@ class TestEncryptionIdempotency:
         encrypted = self.type_adapter.process_literal_param("hello", None)
         double_encrypted = self.type_adapter.process_literal_param(EncryptedValue(encrypted), None)
         assert encrypted == double_encrypted
+
+
+class TestBackendResolution:
+    """Test ``SQLAlchemyEncryptedValue.backend`` configuration handling."""
+
+    def test_backend_returns_configured_adapter(self):
+        """Test that backend returns the adapter configured by ENCRYPTION_METHOD."""
+
+        assert SQLAlchemyEncryptedValue.backend() is FernetAdapter
+
+    def test_backend_raises_when_encryption_method_unset(self, monkeypatch):
+        """Test that backend raises a ValueError when ENCRYPTION_METHOD is unset."""
+
+        monkeypatch.setattr(settings, "ENCRYPTION_METHOD", None)
+
+        with pytest.raises(ValueError, match="ENCRYPTION_METHOD must be set"):
+            SQLAlchemyEncryptedValue.backend()
+
+
+class TestEncryptedValueNoneHandling:
+    """Test ``SQLAlchemyEncryptedValue`` None handling and metadata."""
+
+    def setup_method(self):
+        self.type_adapter = SQLAlchemyEncryptedValue()
+
+    def test_encrypt_cell_none_returns_none(self):
+        """Test that encrypting None returns None without invoking the backend."""
+
+        assert self.type_adapter.encrypt_cell(None) is None
+
+    def test_decrypt_cell_none_returns_none(self):
+        """Test that decrypting None returns None without invoking the backend."""
+
+        assert self.type_adapter.decrypt_cell(None) is None
+
+    def test_python_type_matches_impl(self):
+        """Test that python_type mirrors the LargeBinary impl type."""
+
+        assert self.type_adapter.python_type is self.type_adapter.impl.python_type
+
+
+class TestPGEncryptedArrayLiteralParam:
+    """Test ``SQLAlchemyPGEncryptedArray.process_literal_param`` element encryption."""
+
+    def setup_method(self):
+        self.type_adapter = SQLAlchemyPGEncryptedArray()
+
+    def test_literal_param_none_returns_none(self):
+        """Test that a None array literal returns None."""
+
+        assert self.type_adapter.process_literal_param(None, None) is None
+
+    def test_literal_param_encrypts_each_element(self):
+        """Test that each array element is encrypted for literal SQL expressions."""
+
+        result = self.type_adapter.process_literal_param(["hello", "world"], None)
+
+        assert result is not None
+        assert len(result) == 2
+        assert result[0] != "hello"
+        assert result[1] != "world"

--- a/tests/unit/test_sqlalchemy/test_finalize_sqlalchemy_session.py
+++ b/tests/unit/test_sqlalchemy/test_finalize_sqlalchemy_session.py
@@ -16,11 +16,11 @@ from pydantic_encryption.integrations.sqlalchemy.state import PENDING_DECRYPT_KE
 from pydantic_encryption.types import EncryptedValue
 
 
-class _FinalizeBase(DeclarativeBase):
+class FinalizeBase(DeclarativeBase):
     """Isolated declarative base for finalize_sqlalchemy_session tests."""
 
 
-class _FinalizeUser(_FinalizeBase, DeferredDecryptMixin):
+class FinalizeUser(FinalizeBase, DeferredDecryptMixin):
     """Mapped class with one deferred encrypted column.
 
     Inherits DeferredDecryptMixin so the mapper_configured listener flips
@@ -37,13 +37,13 @@ class _FinalizeUser(_FinalizeBase, DeferredDecryptMixin):
     )
 
 
-def _wrap(value: Any) -> EncryptedValue:
+def wrap_encrypted(value: Any) -> EncryptedValue:
     """Wrap ciphertext in EncryptedValue the way process_result_value does on read."""
 
     return EncryptedValue(SQLAlchemyEncryptedValue().process_bind_param(value, None))
 
 
-class _FakeAsyncSession(SimpleNamespace):
+class FakeAsyncSession(SimpleNamespace):
     """Minimal AsyncSession stand-in exposing the surface finalize_sqlalchemy_session uses."""
 
     def __init__(self, in_transaction: bool) -> None:
@@ -65,11 +65,11 @@ class TestFinalizeSession:
         configure_mappers()
 
     def test_drains_pending_and_commits_when_in_transaction(self):
-        session = _FakeAsyncSession(in_transaction=True)
-        user = _FinalizeUser(id=1, email=_wrap("a@x.com"))
+        session = FakeAsyncSession(in_transaction=True)
+        user = FinalizeUser(id=1, email=wrap_encrypted("a@x.com"))
 
         bucket: dict[type, WeakSet] = defaultdict(WeakSet)
-        bucket[_FinalizeUser].add(user)
+        bucket[FinalizeUser].add(user)
         session.info[PENDING_DECRYPT_KEY] = bucket
 
         asyncio.run(finalize_sqlalchemy_session(session))
@@ -79,18 +79,18 @@ class TestFinalizeSession:
         assert session.commit_calls == 1
 
     def test_skips_commit_when_not_in_transaction(self):
-        session = _FakeAsyncSession(in_transaction=False)
+        session = FakeAsyncSession(in_transaction=False)
 
         asyncio.run(finalize_sqlalchemy_session(session))
 
         assert session.commit_calls == 0
 
     def test_drains_pending_without_commit_when_not_in_transaction(self):
-        session = _FakeAsyncSession(in_transaction=False)
-        user = _FinalizeUser(id=1, email=_wrap("b@x.com"))
+        session = FakeAsyncSession(in_transaction=False)
+        user = FinalizeUser(id=1, email=wrap_encrypted("b@x.com"))
 
         bucket: dict[type, WeakSet] = defaultdict(WeakSet)
-        bucket[_FinalizeUser].add(user)
+        bucket[FinalizeUser].add(user)
         session.info[PENDING_DECRYPT_KEY] = bucket
 
         asyncio.run(finalize_sqlalchemy_session(session))
@@ -104,7 +104,7 @@ class TestFinalizeSession:
 
         events: list[str] = []
 
-        class _RecordingSession(_FakeAsyncSession):
+        class _RecordingSession(FakeAsyncSession):
             async def commit(self_inner) -> None:
                 events.append("commit")
                 await super().commit()
@@ -113,10 +113,10 @@ class TestFinalizeSession:
             events.append("bulk_decrypt")
 
         session = _RecordingSession(in_transaction=True)
-        user = _FinalizeUser(id=1, email=_wrap("c@x.com"))
+        user = FinalizeUser(id=1, email=wrap_encrypted("c@x.com"))
 
         bucket: dict[type, WeakSet] = defaultdict(WeakSet)
-        bucket[_FinalizeUser].add(user)
+        bucket[FinalizeUser].add(user)
         session.info[PENDING_DECRYPT_KEY] = bucket
 
         with patch(

--- a/tests/unit/test_sqlalchemy/test_hashing.py
+++ b/tests/unit/test_sqlalchemy/test_hashing.py
@@ -1,0 +1,73 @@
+from pydantic_encryption.integrations.sqlalchemy.hashing import SQLAlchemyHashedValue
+from pydantic_encryption.types import HashedValue
+
+
+class LiteralProcessorDialect:
+    """Dialect stub exposing the ``literal_processor`` hook used by literal binds."""
+
+    def literal_processor(self, impl):
+        """Return a processor that renders a value as a quoted literal string."""
+
+        def process(value: bytes) -> str:
+            return repr(value)
+
+        return process
+
+
+class TestHashedValue:
+    """Test ``SQLAlchemyHashedValue`` column type behavior."""
+
+    def setup_method(self):
+        self.type_adapter = SQLAlchemyHashedValue()
+
+    def test_hash_produces_argon2_value(self):
+        """Test that hashing a string produces an Argon2 HashedValue."""
+
+        result = self.type_adapter.hash("secret")
+
+        assert isinstance(result, bytes)
+        assert result != b"secret"
+
+    def test_process_bind_param_hashes_value(self):
+        """Test that binding a value hashes it before storage."""
+
+        result = self.type_adapter.process_bind_param("secret", None)
+
+        assert result is not None
+        assert result != b"secret"
+
+    def test_process_bind_param_none_returns_none(self):
+        """Test that binding None returns None."""
+
+        assert self.type_adapter.process_bind_param(None, None) is None
+
+    def test_process_literal_param_hashes_value(self):
+        """Test that a literal value is hashed and rendered through the dialect."""
+
+        result = self.type_adapter.process_literal_param("secret", LiteralProcessorDialect())
+
+        assert result is not None
+        assert "secret" not in str(result)
+
+    def test_process_literal_param_none_returns_none(self):
+        """Test that a None literal value returns None."""
+
+        assert self.type_adapter.process_literal_param(None, LiteralProcessorDialect()) is None
+
+    def test_process_result_value_wraps_hashed_value(self):
+        """Test that a stored hash is wrapped as a HashedValue on read."""
+
+        result = self.type_adapter.process_result_value(b"stored-hash", None)
+
+        assert isinstance(result, HashedValue)
+        assert result == HashedValue(b"stored-hash")
+
+    def test_process_result_value_none_returns_none(self):
+        """Test that a None stored value returns None."""
+
+        assert self.type_adapter.process_result_value(None, None) is None
+
+    def test_python_type_matches_impl(self):
+        """Test that python_type mirrors the LargeBinary impl type."""
+
+        assert self.type_adapter.python_type is self.type_adapter.impl.python_type

--- a/tests/unit/test_sqlalchemy/test_on_access_decrypt.py
+++ b/tests/unit/test_sqlalchemy/test_on_access_decrypt.py
@@ -18,11 +18,11 @@ from pydantic_encryption.types import EncryptedValue
 from tests.factories import User, UserFactory
 
 
-class _OnAccessBase(DeclarativeBase):
+class OnAccessBase(DeclarativeBase):
     """Isolated declarative base for on-access decrypt unit tests."""
 
 
-class _OnAccessRow(_OnAccessBase, DeferredDecryptMixin):
+class OnAccessRow(OnAccessBase, DeferredDecryptMixin):
     """Two encrypted columns to verify per-column batching and scoped decrypts."""
 
     __tablename__ = "_on_access_row"
@@ -36,7 +36,7 @@ class _OnAccessRow(_OnAccessBase, DeferredDecryptMixin):
     )
 
 
-class _OnAccessBytesRow(_OnAccessBase, DeferredDecryptMixin):
+class OnAccessBytesRow(OnAccessBase, DeferredDecryptMixin):
     """Bytes-typed encrypted column for coverage of the same descriptor install path."""
 
     __tablename__ = "_on_access_bytes_row"
@@ -47,32 +47,32 @@ class _OnAccessBytesRow(_OnAccessBase, DeferredDecryptMixin):
     )
 
 
-def _encrypt(value: Any) -> bytes:
+def encrypt_value(value: Any) -> bytes:
     """Encrypt a value via the SQLAlchemyEncryptedValue write path."""
 
     return SQLAlchemyEncryptedValue().process_bind_param(value, None)
 
 
-def _wrap(value: Any) -> EncryptedValue:
+def wrap_encrypted(value: Any) -> EncryptedValue:
     """Wrap ciphertext in EncryptedValue the way process_result_value does on read."""
 
-    return EncryptedValue(_encrypt(value))
+    return EncryptedValue(encrypt_value(value))
 
 
-def _build_row(user: User) -> _OnAccessRow:
-    """Build an _OnAccessRow with encrypted first_name / last_name from a User."""
+def build_row(user: User) -> OnAccessRow:
+    """Build an OnAccessRow with encrypted first_name / last_name from a User."""
 
-    return _OnAccessRow(
+    return OnAccessRow(
         id=user.id,
-        first_name=_wrap(user.first_name),
-        last_name=_wrap(user.last_name),
+        first_name=wrap_encrypted(user.first_name),
+        last_name=wrap_encrypted(user.last_name),
     )
 
 
-def _build_bytes_row(user: User) -> _OnAccessBytesRow:
-    """Build an _OnAccessBytesRow with an encrypted bytes payload from a User."""
+def build_bytes_row(user: User) -> OnAccessBytesRow:
+    """Build an OnAccessBytesRow with an encrypted bytes payload from a User."""
 
-    return _OnAccessBytesRow(id=user.id, payload=_wrap(user.payload))
+    return OnAccessBytesRow(id=user.id, payload=wrap_encrypted(user.payload))
 
 
 @pytest.fixture
@@ -109,19 +109,19 @@ class TestDescriptorInstallation:
         """Test that each encrypted column is wrapped in the on-access descriptor."""
 
         for column_key in ("first_name", "last_name"):
-            descriptor = _OnAccessRow.__dict__[column_key]
+            descriptor = OnAccessRow.__dict__[column_key]
 
             assert isinstance(descriptor, DecryptOnAccessDescriptor)
 
     def test_non_encrypted_columns_untouched(self):
         """Test that non-encrypted columns keep their default SA attribute."""
 
-        assert not isinstance(_OnAccessRow.__dict__["id"], DecryptOnAccessDescriptor)
+        assert not isinstance(OnAccessRow.__dict__["id"], DecryptOnAccessDescriptor)
 
     def test_class_level_access_returns_instrumented_attribute(self):
         """Test that class-level attribute access returns the SA InstrumentedAttribute."""
 
-        attr = _OnAccessRow.first_name
+        attr = OnAccessRow.first_name
 
         assert not isinstance(attr, DecryptOnAccessDescriptor)
         assert hasattr(attr, "key")
@@ -130,7 +130,7 @@ class TestDescriptorInstallation:
     def test_orm_query_expressions_still_work(self, user_fixture: User):
         """Test that ORM query expressions still compile against encrypted columns."""
 
-        stmt = select(_OnAccessRow).where(_OnAccessRow.first_name == user_fixture.first_name)
+        stmt = select(OnAccessRow).where(OnAccessRow.first_name == user_fixture.first_name)
 
         compiled = str(stmt.compile(compile_kwargs={"literal_binds": False}))
         assert "first_name" in compiled
@@ -138,7 +138,7 @@ class TestDescriptorInstallation:
     def test_descriptor_set_delegates_to_wrapped(self, user_fixture: User):
         """Test that assigning through the descriptor stores on SA state."""
 
-        row = _OnAccessRow(id=user_fixture.id)
+        row = OnAccessRow(id=user_fixture.id)
 
         row.first_name = user_fixture.first_name
 
@@ -147,7 +147,7 @@ class TestDescriptorInstallation:
     def test_descriptor_delete_delegates_to_wrapped(self, user_fixture: User):
         """Test that deleting through the descriptor removes the column from SA state."""
 
-        row = _build_row(user_fixture)
+        row = build_row(user_fixture)
 
         del row.first_name
 
@@ -156,7 +156,7 @@ class TestDescriptorInstallation:
     def test_descriptor_exposes_wrapped_key(self):
         """Test that the descriptor exposes the wrapped attribute's column key."""
 
-        descriptor = _OnAccessRow.__dict__["first_name"]
+        descriptor = OnAccessRow.__dict__["first_name"]
 
         assert descriptor.key == "first_name"
 
@@ -167,7 +167,7 @@ class TestBatchAcrossSiblings:
     def test_batches_across_every_row(self, users_batch: list[User]):
         """Test that batch-decrypt touches only the requested column across all rows."""
 
-        rows = [_build_row(user) for user in users_batch]
+        rows = [build_row(user) for user in users_batch]
 
         asyncio.run(decrypt_rows(rows, "first_name"))
 
@@ -180,8 +180,8 @@ class TestBatchAcrossSiblings:
     ):
         """Test that already-decrypted bytes-typed columns are not re-decrypted."""
 
-        row_a = _build_bytes_row(user_fixture)
-        row_b = _build_bytes_row(other_user_fixture)
+        row_a = build_bytes_row(user_fixture)
+        row_b = build_bytes_row(other_user_fixture)
 
         asyncio.run(decrypt_rows([row_a], "payload"))
 
@@ -197,7 +197,7 @@ class TestBatchAcrossSiblings:
     ):
         """Test that one decrypt call is issued per row in the batch."""
 
-        rows = [_build_row(user_fixture), _build_row(other_user_fixture)]
+        rows = [build_row(user_fixture), build_row(other_user_fixture)]
 
         call_count = {"n": 0}
 
@@ -222,27 +222,27 @@ class TestPendingSiblings:
         """Test that pending_siblings returns an empty list for a fresh session."""
 
         session = SimpleNamespace(info={})
-        assert pending_siblings(session, _OnAccessRow) == []
+        assert pending_siblings(session, OnAccessRow) == []
 
     def test_returns_instances_when_class_present_in_bucket(
         self, user_fixture: User, other_user_fixture: User,
     ):
         """Test that pending_siblings returns registered instances for a class."""
 
-        row_a = _OnAccessRow(id=user_fixture.id)
-        row_b = _OnAccessRow(id=other_user_fixture.id)
+        row_a = OnAccessRow(id=user_fixture.id)
+        row_b = OnAccessRow(id=other_user_fixture.id)
         bucket: dict[type, WeakSet] = defaultdict(WeakSet)
-        bucket[_OnAccessRow].add(row_a)
-        bucket[_OnAccessRow].add(row_b)
+        bucket[OnAccessRow].add(row_a)
+        bucket[OnAccessRow].add(row_b)
         session = SimpleNamespace(info={PENDING_DECRYPT_KEY: bucket})
 
-        siblings = pending_siblings(session, _OnAccessRow)
+        siblings = pending_siblings(session, OnAccessRow)
         assert set(siblings) == {row_a, row_b}
 
     def test_returns_empty_list_when_session_is_none(self):
         """Test that pending_siblings returns an empty list when session is None."""
 
-        assert pending_siblings(None, _OnAccessRow) == []
+        assert pending_siblings(None, OnAccessRow) == []
 
 
 class TestDescriptorOnDetachedRead:
@@ -257,7 +257,7 @@ class TestDescriptorOnDetachedRead:
     def test_detached_instance_decrypts_in_place(self, user_fixture: User):
         """Test that reading an encrypted column on a detached instance returns plaintext."""
 
-        row = _build_row(user_fixture)
+        row = build_row(user_fixture)
 
         assert row.first_name == user_fixture.first_name
         assert sa_inspect(row).dict["first_name"] == user_fixture.first_name
@@ -265,7 +265,7 @@ class TestDescriptorOnDetachedRead:
     def test_detached_read_does_not_decrypt_other_columns(self, user_fixture: User):
         """Test that reading one column on a detached row does not eagerly decrypt siblings."""
 
-        row = _build_row(user_fixture)
+        row = build_row(user_fixture)
 
         assert row.first_name == user_fixture.first_name
         assert isinstance(sa_inspect(row).dict["last_name"], EncryptedValue)
@@ -273,7 +273,7 @@ class TestDescriptorOnDetachedRead:
     def test_other_columns_still_readable_when_plaintext(self, user_fixture: User):
         """Test that plaintext values on a detached row read back unchanged."""
 
-        row = _OnAccessRow(id=user_fixture.id, first_name=user_fixture.first_name, last_name=None)
+        row = OnAccessRow(id=user_fixture.id, first_name=user_fixture.first_name, last_name=None)
 
         assert row.first_name == user_fixture.first_name
         assert row.last_name is None
@@ -281,14 +281,14 @@ class TestDescriptorOnDetachedRead:
     def test_plain_integer_columns_never_raise(self, user_fixture: User):
         """Test that non-encrypted columns are readable on a detached row."""
 
-        row = _OnAccessRow(id=user_fixture.id)
+        row = OnAccessRow(id=user_fixture.id)
 
         assert row.id == user_fixture.id
 
     def test_no_greenlet_falls_back_to_sync_decrypt(self, user_fixture: User):
         """Test that a session-bound row outside a greenlet falls back to sync decrypt."""
 
-        row = _build_row(user_fixture)
+        row = build_row(user_fixture)
         fake_session = SimpleNamespace(info={})
 
         with patch(
@@ -306,7 +306,7 @@ class TestDescriptorOnDetachedRead:
     def test_decrypt_method_unblocks_subsequent_reads(self, user_fixture: User):
         """Test that awaiting instance.decrypt() leaves the attribute as plaintext."""
 
-        row = _build_row(user_fixture)
+        row = build_row(user_fixture)
 
         asyncio.run(row.decrypt())
 


### PR DESCRIPTION
## Summary

Enforces the updated leading-underscore convention: a leading underscore is allowed **only** for nested definitions (a function inside another function/method, a class inside another class). All other names drop it.

### Changes
- Methods: `SQLAlchemyBlindIndexValue.process` (was `_process`) and the bulk/encryption/model/registry helper methods.
- Module-level: the `TaggedBytes` type, `LAZY_EXPORTS`, the `defer_crypto_to_async` ContextVar (and its label), the adapter registry state vars (`encryption_backends`, `registry_lock`, …), and assorted helpers.
- Tests: renamed test-only module-level models/helpers and updated all references.

Private **data attributes** (`self._x`, `cls._x`), nested inner functions/classes, and dunders are intentionally left untouched. Collisions were resolved with distinct names (e.g. test helpers `encrypt_value`, `wrap_encrypted`).

### Verification
- `pytest tests/unit` → **363 passed** (integration suite needs Docker; unaffected by renames).
- All changed files compile under 3.13; grep confirms no remaining in-scope leading-underscore definitions.

https://claude.ai/code/session_01PfNPPwW2cfLaSeexRGrhBw

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfNPPwW2cfLaSeexRGrhBw)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical renames and test additions only; no logic changes to encryption, KMS, or SQLAlchemy decrypt paths.
> 
> **Overview**
> This PR **standardizes naming** so a leading underscore is reserved for **nested** definitions only. Across the library, agent sync script, and tests, previously underscored **module-level** names and **public helpers** are renamed (e.g. `TEXT_CACHE`, `LAZY_EXPORTS`, `defer_crypto_to_async`, `TaggedBytes`, registry maps like `encryption_backends` / `registry_lock`, and helpers such as `seal` / `open` / `kms_kwargs` on the AWS path).
> 
> **Runtime behavior is unchanged**—call sites inside the package and tests are updated to match. Private instance/class caches (`_sync_client`, `_deferred`, etc.) stay as-is.
> 
> Tests gain **focused coverage** for registry lazy-loading edge cases, SQLAlchemy hashing literals, and encrypted-column backend / `None` / PG array literal paths, with test fixtures renamed for clarity (`construct_without_crypto`, `FakeSyncKMSClient`, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8440a6c305c017b576c0349c33e3a3dbc93cc59d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->