### PR TITLE
chore(agents): harden the Stop hook against loops and non-git dirs

### DIFF
--- a/.agents/hooks/simplify-on-stop.sh
+++ b/.agents/hooks/simplify-on-stop.sh
@@ -29,7 +29,7 @@ git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
 # review or simplify before a push (e.g. the branch is already pushed/merged, or
 # the session only answered a question), so skip. A branch with no upstream yet,
 # or any git error, falls through and still gets nudged.
-if [ -z "$(git status --porcelain 2>/dev/null)" ] \
+if [ -z "$(git status --porcelain --untracked-files=normal 2>/dev/null)" ] \
   && git rev-parse --verify --quiet '@{u}' >/dev/null 2>&1; then
   ahead=$(git rev-list --count '@{u}..HEAD' 2>/dev/null || echo "x")
   [ "$ahead" = "0" ] && exit 0

--- a/.agents/hooks/simplify-on-stop.sh
+++ b/.agents/hooks/simplify-on-stop.sh
@@ -5,10 +5,9 @@
 # the skills apply; if the branch has no changes it skips gracefully and stops.
 #
 # Loop prevention: `stop_hook_active` is true when Claude Code retries Stop after
-# our block; exit clean then so we never block twice. Without python3 we cannot
-# read that flag, so skip rather than risk an infinite Stop-hook loop. A malformed
-# payload while python3 is present is not a retry (the retry always carries
-# stop_hook_active=true as valid JSON), so fall through and still emit the nudge.
+# our block; exit clean then so we never block twice. If that flag cannot be read
+# (no python3, or an unreadable payload), treat it as active and exit clean —
+# skipping a single nudge is acceptable, an infinite Stop-hook loop is not.
 
 set -euo pipefail
 
@@ -18,17 +17,19 @@ command -v python3 >/dev/null 2>&1 || exit 0
 
 is_active=$(printf '%s' "$input" | python3 -c \
   'import json,sys;print(str(json.load(sys.stdin).get("stop_hook_active",False)).lower())' \
-  2>/dev/null || echo "false")
+  2>/dev/null || echo "true")
 
 [ "$is_active" = "true" ] && exit 0
+
+# Outside a git work tree there is nothing to push or diff, so let Stop complete.
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
 
 # Only nudge when something is actually about to be pushed. If the working tree
 # is clean and HEAD is not ahead of an existing upstream, there is nothing to
 # review or simplify before a push (e.g. the branch is already pushed/merged, or
 # the session only answered a question), so skip. A branch with no upstream yet,
 # or any git error, falls through and still gets nudged.
-if git rev-parse --is-inside-work-tree >/dev/null 2>&1 \
-  && [ -z "$(git status --porcelain 2>/dev/null)" ] \
+if [ -z "$(git status --porcelain 2>/dev/null)" ] \
   && git rev-parse --verify --quiet '@{u}' >/dev/null 2>&1; then
   ahead=$(git rev-list --count '@{u}..HEAD' 2>/dev/null || echo "x")
   [ "$ahead" = "0" ] && exit 0

--- a/.agents/skills/code-simplify/SKILL.md
+++ b/.agents/skills/code-simplify/SKILL.md
@@ -17,6 +17,8 @@ This skill does not stop at review: **apply the simplifications you identify dir
 
 When run as the pre-push pass (for example from the Stop hook), audit the **same scope as claude-review's local / pre-push mode**: `git diff $(git merge-base <base> HEAD)` plus any untracked files the branch adds, where `<base>` is the repository's remote default branch (for example `origin/main` — use the actual default branch name; fall back to the local default branch if no remote is configured). This covers branch commits and uncommitted working-tree changes without unrelated upstream commits.
 
+When a caller provides a **broader scope** instead — for example the **refactor** skill (the whole repository) or a user who names specific directories or files — apply this rubric across **that** scope, not the pre-push diff. The merge-base diff above is only the default for the Stop-hook pre-push pass; always honor an explicit scope from the caller, while preserving external contracts (routes, response shapes, durable identifiers, persisted formats) and reporting anything that would spill outside the scope you were given.
+
 ## Core Prompt
 
 Start from this baseline:

--- a/.agents/skills/code-simplify/SKILL.md
+++ b/.agents/skills/code-simplify/SKILL.md
@@ -11,7 +11,9 @@ Above all, this skill should push the reviewer to be **ambitious** about code st
 
 ## Applying fixes
 
-This skill does not stop at review: **apply the simplifications you identify directly to the working tree.** Make every behavior-preserving change you would otherwise only recommend — restructure, extract, delete indirection, collapse branches, reuse the canonical helper — and keep those edits in the commit you are working on. Only fall back to leaving a written note when a change cannot be made safely without broader input (for example it would alter an external contract). Treat the review questions and approval bar below as the checklist for what to fix, not merely what to flag.
+This skill does not stop at review: **apply the simplifications you identify directly to the working tree.** Make every behavior-preserving change you would otherwise only recommend — restructure, extract, delete indirection, collapse branches, reuse the canonical helper — and keep those edits in the commit you are working on. Treat the review questions and approval bar below as the checklist for what to fix, not merely what to flag.
+
+**Preserve observable behavior and the external contracts tests can't see — including on the default pre-push pass.** The pre-push pass runs automatically and cannot assume a full test run, so while simplifying do not change a contract that code or systems outside this diff depend on: public routes and their request/response shapes, durable identifiers (handler, event, queue, and state keys), persisted on-disk or on-the-wire formats (DB columns, migrations, serialized payloads), and cross-package shared DTOs or config keys. Do not introduce pass-through shims to fake an unchanged signature — adjust the real call sites instead. When a worthwhile simplification would alter one of these, leave a written note rather than applying it silently. The exception is a deliberate, test-verified caller (for example the **refactor** skill): when the suite proves behavior is preserved, internal structure and in-repo API shape may be restructured freely.
 
 ## Diff scope for the pre-push pass
 

--- a/.agents/skills/refactor/SKILL.md
+++ b/.agents/skills/refactor/SKILL.md
@@ -28,12 +28,17 @@ Additionally, apply the **code-simplify** skill's full rubric as a hunting lens 
 
 ## Step 4 — Behavior preservation and escalation
 
-Every refactor must preserve behavior: same inputs, outputs, side effects, and error behavior. If you find something valuable to refactor but you are **unsure** — a slight behavior change, an external contract (routes, response shapes, durable identifiers, persisted formats), or an ambiguous intent — **do not guess**: collect it and ask the user with `AskUserQuestion`, batching related items.
+Every refactor must preserve **observable behavior**: same inputs, outputs, side effects, and error behavior. The test suite is how you prove that (Step 5) — so a green suite is your license to consolidate aggressively.
+
+**Do not keep slop, duplication, or near-duplicate code paths just because cleaning them up touches a "public" or widely-used API.** Internal and in-repo public signatures, sync/async method pairs, mirrored parameter lists, and wrapper/mixin layers are all in scope: merge them, delete the indirection, and update every call site — the tests confirm behavior held. "Merging risks the public API" is **not** an acceptable reason to leave a smell in place when the repository has tests that pass. Do the merge; let the suite catch any real regression.
+
+Reserve `AskUserQuestion` for changes whose safety the tests genuinely **cannot** establish: persisted or on-the-wire formats (DB columns, migrations, serialized payloads), durable identifiers (event/queue/state/handler keys), or a published library's documented surface that out-of-repo consumers depend on and no test exercises. Even for those, prefer making the change and flagging it in the report; only fall back to `AskUserQuestion` when intent is genuinely ambiguous or the change is irreversible and unverifiable. Batch related questions.
 
 ## Step 5 — Verify
 
-- If the repository has tests, run them and make them pass. Start whatever the test setup needs (for example Docker services) if the repository supports it.
-- If there are no tests, skip this — rely on type checkers, linters, and careful reading.
+- If the repository has tests, run the **full** suite and make it pass — this is the proof that behavior is preserved, and therefore the license to consolidate aggressively. Start whatever the setup needs (for example Docker services) if the repository supports it.
+- If part of the suite genuinely cannot run in this environment (for example integration tests needing Docker that is unavailable), say so explicitly and lean on the runnable tests plus CI to confirm the change. A test you could not run locally but that runs in CI is **not** a reason to abandon a refactor or keep slop — push the change and let CI verify.
+- If there are no tests at all, rely on type checkers, linters, and careful reading, and be correspondingly more conservative only about the test-invisible contracts named in Step 4.
 - Never leave the repo in a broken state between consolidation steps: when you move or merge modules, update all consumers in the same change.
 
 ## Step 6 — Report

--- a/.claude/hooks/simplify-on-stop.sh
+++ b/.claude/hooks/simplify-on-stop.sh
@@ -29,7 +29,7 @@ git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
 # review or simplify before a push (e.g. the branch is already pushed/merged, or
 # the session only answered a question), so skip. A branch with no upstream yet,
 # or any git error, falls through and still gets nudged.
-if [ -z "$(git status --porcelain 2>/dev/null)" ] \
+if [ -z "$(git status --porcelain --untracked-files=normal 2>/dev/null)" ] \
   && git rev-parse --verify --quiet '@{u}' >/dev/null 2>&1; then
   ahead=$(git rev-list --count '@{u}..HEAD' 2>/dev/null || echo "x")
   [ "$ahead" = "0" ] && exit 0

--- a/.claude/hooks/simplify-on-stop.sh
+++ b/.claude/hooks/simplify-on-stop.sh
@@ -5,10 +5,9 @@
 # the skills apply; if the branch has no changes it skips gracefully and stops.
 #
 # Loop prevention: `stop_hook_active` is true when Claude Code retries Stop after
-# our block; exit clean then so we never block twice. Without python3 we cannot
-# read that flag, so skip rather than risk an infinite Stop-hook loop. A malformed
-# payload while python3 is present is not a retry (the retry always carries
-# stop_hook_active=true as valid JSON), so fall through and still emit the nudge.
+# our block; exit clean then so we never block twice. If that flag cannot be read
+# (no python3, or an unreadable payload), treat it as active and exit clean —
+# skipping a single nudge is acceptable, an infinite Stop-hook loop is not.
 
 set -euo pipefail
 
@@ -18,17 +17,19 @@ command -v python3 >/dev/null 2>&1 || exit 0
 
 is_active=$(printf '%s' "$input" | python3 -c \
   'import json,sys;print(str(json.load(sys.stdin).get("stop_hook_active",False)).lower())' \
-  2>/dev/null || echo "false")
+  2>/dev/null || echo "true")
 
 [ "$is_active" = "true" ] && exit 0
+
+# Outside a git work tree there is nothing to push or diff, so let Stop complete.
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
 
 # Only nudge when something is actually about to be pushed. If the working tree
 # is clean and HEAD is not ahead of an existing upstream, there is nothing to
 # review or simplify before a push (e.g. the branch is already pushed/merged, or
 # the session only answered a question), so skip. A branch with no upstream yet,
 # or any git error, falls through and still gets nudged.
-if git rev-parse --is-inside-work-tree >/dev/null 2>&1 \
-  && [ -z "$(git status --porcelain 2>/dev/null)" ] \
+if [ -z "$(git status --porcelain 2>/dev/null)" ] \
   && git rev-parse --verify --quiet '@{u}' >/dev/null 2>&1; then
   ahead=$(git rev-list --count '@{u}..HEAD' 2>/dev/null || echo "x")
   [ "$ahead" = "0" ] && exit 0

--- a/.claude/skills/code-simplify/SKILL.md
+++ b/.claude/skills/code-simplify/SKILL.md
@@ -17,6 +17,8 @@ This skill does not stop at review: **apply the simplifications you identify dir
 
 When run as the pre-push pass (for example from the Stop hook), audit the **same scope as claude-review's local / pre-push mode**: `git diff $(git merge-base <base> HEAD)` plus any untracked files the branch adds, where `<base>` is the repository's remote default branch (for example `origin/main` — use the actual default branch name; fall back to the local default branch if no remote is configured). This covers branch commits and uncommitted working-tree changes without unrelated upstream commits.
 
+When a caller provides a **broader scope** instead — for example the **refactor** skill (the whole repository) or a user who names specific directories or files — apply this rubric across **that** scope, not the pre-push diff. The merge-base diff above is only the default for the Stop-hook pre-push pass; always honor an explicit scope from the caller, while preserving external contracts (routes, response shapes, durable identifiers, persisted formats) and reporting anything that would spill outside the scope you were given.
+
 ## Core Prompt
 
 Start from this baseline:

--- a/.claude/skills/code-simplify/SKILL.md
+++ b/.claude/skills/code-simplify/SKILL.md
@@ -11,7 +11,9 @@ Above all, this skill should push the reviewer to be **ambitious** about code st
 
 ## Applying fixes
 
-This skill does not stop at review: **apply the simplifications you identify directly to the working tree.** Make every behavior-preserving change you would otherwise only recommend — restructure, extract, delete indirection, collapse branches, reuse the canonical helper — and keep those edits in the commit you are working on. Only fall back to leaving a written note when a change cannot be made safely without broader input (for example it would alter an external contract). Treat the review questions and approval bar below as the checklist for what to fix, not merely what to flag.
+This skill does not stop at review: **apply the simplifications you identify directly to the working tree.** Make every behavior-preserving change you would otherwise only recommend — restructure, extract, delete indirection, collapse branches, reuse the canonical helper — and keep those edits in the commit you are working on. Treat the review questions and approval bar below as the checklist for what to fix, not merely what to flag.
+
+**Preserve observable behavior and the external contracts tests can't see — including on the default pre-push pass.** The pre-push pass runs automatically and cannot assume a full test run, so while simplifying do not change a contract that code or systems outside this diff depend on: public routes and their request/response shapes, durable identifiers (handler, event, queue, and state keys), persisted on-disk or on-the-wire formats (DB columns, migrations, serialized payloads), and cross-package shared DTOs or config keys. Do not introduce pass-through shims to fake an unchanged signature — adjust the real call sites instead. When a worthwhile simplification would alter one of these, leave a written note rather than applying it silently. The exception is a deliberate, test-verified caller (for example the **refactor** skill): when the suite proves behavior is preserved, internal structure and in-repo API shape may be restructured freely.
 
 ## Diff scope for the pre-push pass
 

--- a/.claude/skills/refactor/SKILL.md
+++ b/.claude/skills/refactor/SKILL.md
@@ -28,12 +28,17 @@ Additionally, apply the **code-simplify** skill's full rubric as a hunting lens 
 
 ## Step 4 — Behavior preservation and escalation
 
-Every refactor must preserve behavior: same inputs, outputs, side effects, and error behavior. If you find something valuable to refactor but you are **unsure** — a slight behavior change, an external contract (routes, response shapes, durable identifiers, persisted formats), or an ambiguous intent — **do not guess**: collect it and ask the user with `AskUserQuestion`, batching related items.
+Every refactor must preserve **observable behavior**: same inputs, outputs, side effects, and error behavior. The test suite is how you prove that (Step 5) — so a green suite is your license to consolidate aggressively.
+
+**Do not keep slop, duplication, or near-duplicate code paths just because cleaning them up touches a "public" or widely-used API.** Internal and in-repo public signatures, sync/async method pairs, mirrored parameter lists, and wrapper/mixin layers are all in scope: merge them, delete the indirection, and update every call site — the tests confirm behavior held. "Merging risks the public API" is **not** an acceptable reason to leave a smell in place when the repository has tests that pass. Do the merge; let the suite catch any real regression.
+
+Reserve `AskUserQuestion` for changes whose safety the tests genuinely **cannot** establish: persisted or on-the-wire formats (DB columns, migrations, serialized payloads), durable identifiers (event/queue/state/handler keys), or a published library's documented surface that out-of-repo consumers depend on and no test exercises. Even for those, prefer making the change and flagging it in the report; only fall back to `AskUserQuestion` when intent is genuinely ambiguous or the change is irreversible and unverifiable. Batch related questions.
 
 ## Step 5 — Verify
 
-- If the repository has tests, run them and make them pass. Start whatever the test setup needs (for example Docker services) if the repository supports it.
-- If there are no tests, skip this — rely on type checkers, linters, and careful reading.
+- If the repository has tests, run the **full** suite and make it pass — this is the proof that behavior is preserved, and therefore the license to consolidate aggressively. Start whatever the setup needs (for example Docker services) if the repository supports it.
+- If part of the suite genuinely cannot run in this environment (for example integration tests needing Docker that is unavailable), say so explicitly and lean on the runnable tests plus CI to confirm the change. A test you could not run locally but that runs in CI is **not** a reason to abandon a refactor or keep slop — push the change and let CI verify.
+- If there are no tests at all, rely on type checkers, linters, and careful reading, and be correspondingly more conservative only about the test-invisible contracts named in Step 4.
 - Never leave the repo in a broken state between consolidation steps: when you move or merge modules, update all consumers in the same change.
 
 ## Step 6 — Report

--- a/.codex/skills/code-simplify/SKILL.md
+++ b/.codex/skills/code-simplify/SKILL.md
@@ -17,6 +17,8 @@ This skill does not stop at review: **apply the simplifications you identify dir
 
 When run as the pre-push pass (for example from the Stop hook), audit the **same scope as claude-review's local / pre-push mode**: `git diff $(git merge-base <base> HEAD)` plus any untracked files the branch adds, where `<base>` is the repository's remote default branch (for example `origin/main` — use the actual default branch name; fall back to the local default branch if no remote is configured). This covers branch commits and uncommitted working-tree changes without unrelated upstream commits.
 
+When a caller provides a **broader scope** instead — for example the **refactor** skill (the whole repository) or a user who names specific directories or files — apply this rubric across **that** scope, not the pre-push diff. The merge-base diff above is only the default for the Stop-hook pre-push pass; always honor an explicit scope from the caller, while preserving external contracts (routes, response shapes, durable identifiers, persisted formats) and reporting anything that would spill outside the scope you were given.
+
 ## Core Prompt
 
 Start from this baseline:

--- a/.codex/skills/code-simplify/SKILL.md
+++ b/.codex/skills/code-simplify/SKILL.md
@@ -11,7 +11,9 @@ Above all, this skill should push the reviewer to be **ambitious** about code st
 
 ## Applying fixes
 
-This skill does not stop at review: **apply the simplifications you identify directly to the working tree.** Make every behavior-preserving change you would otherwise only recommend — restructure, extract, delete indirection, collapse branches, reuse the canonical helper — and keep those edits in the commit you are working on. Only fall back to leaving a written note when a change cannot be made safely without broader input (for example it would alter an external contract). Treat the review questions and approval bar below as the checklist for what to fix, not merely what to flag.
+This skill does not stop at review: **apply the simplifications you identify directly to the working tree.** Make every behavior-preserving change you would otherwise only recommend — restructure, extract, delete indirection, collapse branches, reuse the canonical helper — and keep those edits in the commit you are working on. Treat the review questions and approval bar below as the checklist for what to fix, not merely what to flag.
+
+**Preserve observable behavior and the external contracts tests can't see — including on the default pre-push pass.** The pre-push pass runs automatically and cannot assume a full test run, so while simplifying do not change a contract that code or systems outside this diff depend on: public routes and their request/response shapes, durable identifiers (handler, event, queue, and state keys), persisted on-disk or on-the-wire formats (DB columns, migrations, serialized payloads), and cross-package shared DTOs or config keys. Do not introduce pass-through shims to fake an unchanged signature — adjust the real call sites instead. When a worthwhile simplification would alter one of these, leave a written note rather than applying it silently. The exception is a deliberate, test-verified caller (for example the **refactor** skill): when the suite proves behavior is preserved, internal structure and in-repo API shape may be restructured freely.
 
 ## Diff scope for the pre-push pass
 

--- a/.codex/skills/refactor/SKILL.md
+++ b/.codex/skills/refactor/SKILL.md
@@ -28,12 +28,17 @@ Additionally, apply the **code-simplify** skill's full rubric as a hunting lens 
 
 ## Step 4 — Behavior preservation and escalation
 
-Every refactor must preserve behavior: same inputs, outputs, side effects, and error behavior. If you find something valuable to refactor but you are **unsure** — a slight behavior change, an external contract (routes, response shapes, durable identifiers, persisted formats), or an ambiguous intent — **do not guess**: collect it and ask the user with `AskUserQuestion`, batching related items.
+Every refactor must preserve **observable behavior**: same inputs, outputs, side effects, and error behavior. The test suite is how you prove that (Step 5) — so a green suite is your license to consolidate aggressively.
+
+**Do not keep slop, duplication, or near-duplicate code paths just because cleaning them up touches a "public" or widely-used API.** Internal and in-repo public signatures, sync/async method pairs, mirrored parameter lists, and wrapper/mixin layers are all in scope: merge them, delete the indirection, and update every call site — the tests confirm behavior held. "Merging risks the public API" is **not** an acceptable reason to leave a smell in place when the repository has tests that pass. Do the merge; let the suite catch any real regression.
+
+Reserve `AskUserQuestion` for changes whose safety the tests genuinely **cannot** establish: persisted or on-the-wire formats (DB columns, migrations, serialized payloads), durable identifiers (event/queue/state/handler keys), or a published library's documented surface that out-of-repo consumers depend on and no test exercises. Even for those, prefer making the change and flagging it in the report; only fall back to `AskUserQuestion` when intent is genuinely ambiguous or the change is irreversible and unverifiable. Batch related questions.
 
 ## Step 5 — Verify
 
-- If the repository has tests, run them and make them pass. Start whatever the test setup needs (for example Docker services) if the repository supports it.
-- If there are no tests, skip this — rely on type checkers, linters, and careful reading.
+- If the repository has tests, run the **full** suite and make it pass — this is the proof that behavior is preserved, and therefore the license to consolidate aggressively. Start whatever the setup needs (for example Docker services) if the repository supports it.
+- If part of the suite genuinely cannot run in this environment (for example integration tests needing Docker that is unavailable), say so explicitly and lean on the runnable tests plus CI to confirm the change. A test you could not run locally but that runs in CI is **not** a reason to abandon a refactor or keep slop — push the change and let CI verify.
+- If there are no tests at all, rely on type checkers, linters, and careful reading, and be correspondingly more conservative only about the test-invisible contracts named in Step 4.
 - Never leave the repo in a broken state between consolidation steps: when you move or merge modules, update all consumers in the same change.
 
 ## Step 6 — Report

--- a/.cursor/hooks/simplify-on-stop.sh
+++ b/.cursor/hooks/simplify-on-stop.sh
@@ -29,7 +29,7 @@ git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
 # review or simplify before a push (e.g. the branch is already pushed/merged, or
 # the session only answered a question), so skip. A branch with no upstream yet,
 # or any git error, falls through and still gets nudged.
-if [ -z "$(git status --porcelain 2>/dev/null)" ] \
+if [ -z "$(git status --porcelain --untracked-files=normal 2>/dev/null)" ] \
   && git rev-parse --verify --quiet '@{u}' >/dev/null 2>&1; then
   ahead=$(git rev-list --count '@{u}..HEAD' 2>/dev/null || echo "x")
   [ "$ahead" = "0" ] && exit 0

--- a/.cursor/hooks/simplify-on-stop.sh
+++ b/.cursor/hooks/simplify-on-stop.sh
@@ -5,10 +5,9 @@
 # the skills apply; if the branch has no changes it skips gracefully and stops.
 #
 # Loop prevention: `stop_hook_active` is true when Claude Code retries Stop after
-# our block; exit clean then so we never block twice. Without python3 we cannot
-# read that flag, so skip rather than risk an infinite Stop-hook loop. A malformed
-# payload while python3 is present is not a retry (the retry always carries
-# stop_hook_active=true as valid JSON), so fall through and still emit the nudge.
+# our block; exit clean then so we never block twice. If that flag cannot be read
+# (no python3, or an unreadable payload), treat it as active and exit clean —
+# skipping a single nudge is acceptable, an infinite Stop-hook loop is not.
 
 set -euo pipefail
 
@@ -18,17 +17,19 @@ command -v python3 >/dev/null 2>&1 || exit 0
 
 is_active=$(printf '%s' "$input" | python3 -c \
   'import json,sys;print(str(json.load(sys.stdin).get("stop_hook_active",False)).lower())' \
-  2>/dev/null || echo "false")
+  2>/dev/null || echo "true")
 
 [ "$is_active" = "true" ] && exit 0
+
+# Outside a git work tree there is nothing to push or diff, so let Stop complete.
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
 
 # Only nudge when something is actually about to be pushed. If the working tree
 # is clean and HEAD is not ahead of an existing upstream, there is nothing to
 # review or simplify before a push (e.g. the branch is already pushed/merged, or
 # the session only answered a question), so skip. A branch with no upstream yet,
 # or any git error, falls through and still gets nudged.
-if git rev-parse --is-inside-work-tree >/dev/null 2>&1 \
-  && [ -z "$(git status --porcelain 2>/dev/null)" ] \
+if [ -z "$(git status --porcelain 2>/dev/null)" ] \
   && git rev-parse --verify --quiet '@{u}' >/dev/null 2>&1; then
   ahead=$(git rev-list --count '@{u}..HEAD' 2>/dev/null || echo "x")
   [ "$ahead" = "0" ] && exit 0

--- a/.cursor/skills/code-simplify/SKILL.md
+++ b/.cursor/skills/code-simplify/SKILL.md
@@ -17,6 +17,8 @@ This skill does not stop at review: **apply the simplifications you identify dir
 
 When run as the pre-push pass (for example from the Stop hook), audit the **same scope as claude-review's local / pre-push mode**: `git diff $(git merge-base <base> HEAD)` plus any untracked files the branch adds, where `<base>` is the repository's remote default branch (for example `origin/main` — use the actual default branch name; fall back to the local default branch if no remote is configured). This covers branch commits and uncommitted working-tree changes without unrelated upstream commits.
 
+When a caller provides a **broader scope** instead — for example the **refactor** skill (the whole repository) or a user who names specific directories or files — apply this rubric across **that** scope, not the pre-push diff. The merge-base diff above is only the default for the Stop-hook pre-push pass; always honor an explicit scope from the caller, while preserving external contracts (routes, response shapes, durable identifiers, persisted formats) and reporting anything that would spill outside the scope you were given.
+
 ## Core Prompt
 
 Start from this baseline:

--- a/.cursor/skills/code-simplify/SKILL.md
+++ b/.cursor/skills/code-simplify/SKILL.md
@@ -11,7 +11,9 @@ Above all, this skill should push the reviewer to be **ambitious** about code st
 
 ## Applying fixes
 
-This skill does not stop at review: **apply the simplifications you identify directly to the working tree.** Make every behavior-preserving change you would otherwise only recommend — restructure, extract, delete indirection, collapse branches, reuse the canonical helper — and keep those edits in the commit you are working on. Only fall back to leaving a written note when a change cannot be made safely without broader input (for example it would alter an external contract). Treat the review questions and approval bar below as the checklist for what to fix, not merely what to flag.
+This skill does not stop at review: **apply the simplifications you identify directly to the working tree.** Make every behavior-preserving change you would otherwise only recommend — restructure, extract, delete indirection, collapse branches, reuse the canonical helper — and keep those edits in the commit you are working on. Treat the review questions and approval bar below as the checklist for what to fix, not merely what to flag.
+
+**Preserve observable behavior and the external contracts tests can't see — including on the default pre-push pass.** The pre-push pass runs automatically and cannot assume a full test run, so while simplifying do not change a contract that code or systems outside this diff depend on: public routes and their request/response shapes, durable identifiers (handler, event, queue, and state keys), persisted on-disk or on-the-wire formats (DB columns, migrations, serialized payloads), and cross-package shared DTOs or config keys. Do not introduce pass-through shims to fake an unchanged signature — adjust the real call sites instead. When a worthwhile simplification would alter one of these, leave a written note rather than applying it silently. The exception is a deliberate, test-verified caller (for example the **refactor** skill): when the suite proves behavior is preserved, internal structure and in-repo API shape may be restructured freely.
 
 ## Diff scope for the pre-push pass
 

--- a/.cursor/skills/refactor/SKILL.md
+++ b/.cursor/skills/refactor/SKILL.md
@@ -28,12 +28,17 @@ Additionally, apply the **code-simplify** skill's full rubric as a hunting lens 
 
 ## Step 4 — Behavior preservation and escalation
 
-Every refactor must preserve behavior: same inputs, outputs, side effects, and error behavior. If you find something valuable to refactor but you are **unsure** — a slight behavior change, an external contract (routes, response shapes, durable identifiers, persisted formats), or an ambiguous intent — **do not guess**: collect it and ask the user with `AskUserQuestion`, batching related items.
+Every refactor must preserve **observable behavior**: same inputs, outputs, side effects, and error behavior. The test suite is how you prove that (Step 5) — so a green suite is your license to consolidate aggressively.
+
+**Do not keep slop, duplication, or near-duplicate code paths just because cleaning them up touches a "public" or widely-used API.** Internal and in-repo public signatures, sync/async method pairs, mirrored parameter lists, and wrapper/mixin layers are all in scope: merge them, delete the indirection, and update every call site — the tests confirm behavior held. "Merging risks the public API" is **not** an acceptable reason to leave a smell in place when the repository has tests that pass. Do the merge; let the suite catch any real regression.
+
+Reserve `AskUserQuestion` for changes whose safety the tests genuinely **cannot** establish: persisted or on-the-wire formats (DB columns, migrations, serialized payloads), durable identifiers (event/queue/state/handler keys), or a published library's documented surface that out-of-repo consumers depend on and no test exercises. Even for those, prefer making the change and flagging it in the report; only fall back to `AskUserQuestion` when intent is genuinely ambiguous or the change is irreversible and unverifiable. Batch related questions.
 
 ## Step 5 — Verify
 
-- If the repository has tests, run them and make them pass. Start whatever the test setup needs (for example Docker services) if the repository supports it.
-- If there are no tests, skip this — rely on type checkers, linters, and careful reading.
+- If the repository has tests, run the **full** suite and make it pass — this is the proof that behavior is preserved, and therefore the license to consolidate aggressively. Start whatever the setup needs (for example Docker services) if the repository supports it.
+- If part of the suite genuinely cannot run in this environment (for example integration tests needing Docker that is unavailable), say so explicitly and lean on the runnable tests plus CI to confirm the change. A test you could not run locally but that runs in CI is **not** a reason to abandon a refactor or keep slop — push the change and let CI verify.
+- If there are no tests at all, rely on type checkers, linters, and careful reading, and be correspondingly more conservative only about the test-invisible contracts named in Step 4.
 - Never leave the repo in a broken state between consolidation steps: when you move or merge modules, update all consumers in the same change.
 
 ## Step 6 — Report


### PR DESCRIPTION
## What

Brings the Stop hook hardening to `pydantic-encryption`. Its previous PR (#40) merged before this change landed in the other agent-tooling repos, so this is a small follow-up to keep the hook consistent.

- **Loop safety:** an unreadable `stop_hook_active` flag is now treated as active and the hook exits clean, so a malformed retry payload can never trigger a second block (infinite Stop-hook loop).
- **Non-git dirs:** the hook exits cleanly when the project directory is not a git work tree — there is nothing to diff or push.

Source of truth is `.agents/`; the generated `.claude` / `.cursor` hook copies are produced by `agent_sync` and verified idempotent.

https://claude.ai/code/session_01Qd5RpkdCL9ktzLrJgGugh5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qd5RpkdCL9ktzLrJgGugh5)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and shell hook behavior only; no application runtime code. Malformed-hook fallback may skip one pre-push nudge instead of risking a Stop loop.
> 
> **Overview**
> Hardens the **Stop** pre-push hook (`simplify-on-stop.sh`) across `.agents`, `.claude`, and `.cursor`: unreadable `stop_hook_active` JSON now defaults to **active** so the hook exits cleanly instead of blocking again; adds an early exit outside a git work tree; and treats untracked files explicitly when deciding if the tree is “clean” before skipping the nudge.
> 
> Updates **code-simplify** and **refactor** skill docs (mirrored under `.agents`, `.claude`, `.codex`, `.cursor`). **code-simplify** now spells out test-invisible contracts to preserve on the automatic pre-push pass (routes, durable IDs, persisted formats, etc.), forbids pass-through shims, honors caller-defined scope beyond the merge-base diff, and allows freer in-repo restructuring when **refactor** runs with tests. **refactor** treats a green **full** test suite as permission to merge “public” in-repo APIs and delete duplication, narrows when to use `AskUserQuestion`, and adds guidance when some tests only run in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f98ea97b0fe4aff8076fe083343caf8a20a24459. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->