### PR TITLE
refactor: remove pass-through shims, duplicate fixtures/asserts, and pop+flatten drift

### DIFF
--- a/pydantic_encryption/integrations/sqlalchemy/bulk.py
+++ b/pydantic_encryption/integrations/sqlalchemy/bulk.py
@@ -197,26 +197,29 @@ async def bulk_decrypt_entities(entities: Any | Iterable[Any] | None) -> None:
     await decrypt_assignments(backend, assignments)
 
 
+def pop_pending_rows(session: AsyncSession) -> list[Any]:
+    """Remove this session's pending-decrypt bucket and flatten it into a row list."""
+
+    pending = session.info.pop(PENDING_DECRYPT_KEY, None) or {}
+
+    return [row for rows in pending.values() for row in rows]
+
+
 async def decrypt_pending_fields(session: AsyncSession) -> None:
     """Force-decrypt every encrypted column on every instance bucketed in this session."""
 
-    pending = session.info.pop(PENDING_DECRYPT_KEY, None)
-    if not pending:
-        return
-
-    await bulk_decrypt_entities([row for rows in pending.values() for row in rows])
+    await bulk_decrypt_entities(pop_pending_rows(session))
 
 
 async def finalize_sqlalchemy_session(session: AsyncSession) -> None:
     """Commit to release the pooled connection, then run the captured pending decrypt batch."""
 
-    pending = session.info.pop(PENDING_DECRYPT_KEY, None)
+    rows = pop_pending_rows(session)
 
     if session.in_transaction():
         await session.commit()
 
-    if pending:
-        await bulk_decrypt_entities([row for rows in pending.values() for row in rows])
+    await bulk_decrypt_entities(rows)
 
 
 __all__ = [

--- a/pydantic_encryption/models/base.py
+++ b/pydantic_encryption/models/base.py
@@ -5,8 +5,8 @@ from typing import Any, ClassVar, Self
 
 from pydantic_super_model import AnnotatedFieldInfo, SuperModelPydanticMixin
 
-from pydantic_encryption.adapters import hashing
 from pydantic_encryption.adapters.base import BlindIndexAdapter, EncryptionAdapter
+from pydantic_encryption.adapters.hashing.argon2 import Argon2Adapter
 from pydantic_encryption.adapters.registry import get_blind_index_backend, get_encryption_backend
 from pydantic_encryption.config import settings
 from pydantic_encryption.normalization import normalize_value
@@ -200,7 +200,7 @@ class SecureModel:
             return
 
         for field_name, value in fields.items():
-            setattr(self, field_name, hashing.argon2.Argon2Adapter.hash(value))
+            setattr(self, field_name, Argon2Adapter.hash(value))
 
     def blind_index_data(self) -> None:
         """Compute blind indexes for fields annotated with ``BlindIndex`` in-place."""
@@ -245,7 +245,7 @@ class SecureModel:
             return
 
         await self.async_apply(
-            [(name, hashing.argon2.Argon2Adapter.async_hash(val)) for name, val in fields.items()]
+            [(name, Argon2Adapter.async_hash(val)) for name, val in fields.items()]
         )
 
     async def async_blind_index_data(self) -> None:
@@ -320,11 +320,6 @@ class SecureModel:
 
 class BaseModel(SuperModelPydanticMixin, SecureModel):
     """Pydantic base model with automatic encryption, hashing, and blind indexing."""
-
-    def get_annotated_fields(self, *annotations: type) -> dict[str, AnnotatedFieldInfo]:
-        """Return annotated field info objects keyed by field name."""
-
-        return super().get_annotated_fields(*annotations)
 
     def model_post_init(self, context: Any, /) -> None:
         self.default_post_init()

--- a/tests/unit/test_adapters.py
+++ b/tests/unit/test_adapters.py
@@ -15,7 +15,6 @@ class TestFernetAdapter:
         encrypted = FernetAdapter.encrypt(plaintext)
 
         assert isinstance(encrypted, EncryptedValue)
-        assert isinstance(encrypted, EncryptedValue)
         assert encrypted != plaintext.encode("utf-8")
 
     def test_encrypt_bytes(self):
@@ -23,7 +22,6 @@ class TestFernetAdapter:
         plaintext = b"secret bytes"
         encrypted = FernetAdapter.encrypt(plaintext)
 
-        assert isinstance(encrypted, EncryptedValue)
         assert isinstance(encrypted, EncryptedValue)
 
     def test_decrypt_returns_string(self):
@@ -84,7 +82,6 @@ class TestArgon2Adapter:
         hashed = Argon2Adapter.hash(value)
 
         assert isinstance(hashed, HashedValue)
-        assert isinstance(hashed, HashedValue)
         assert hashed != value.encode("utf-8")
 
     def test_hash_bytes(self):
@@ -92,7 +89,6 @@ class TestArgon2Adapter:
         value = b"password123"
         hashed = Argon2Adapter.hash(value)
 
-        assert isinstance(hashed, HashedValue)
         assert isinstance(hashed, HashedValue)
 
     def test_hash_already_hashed_returns_same(self):
@@ -129,14 +125,12 @@ class TestArgon2Adapter:
         hashed = Argon2Adapter.hash(value)
 
         assert isinstance(hashed, HashedValue)
-        assert isinstance(hashed, HashedValue)
 
     def test_hash_unicode(self):
         """Test hashing unicode characters."""
         value = "日本語パスワード🔒"
         hashed = Argon2Adapter.hash(value)
 
-        assert isinstance(hashed, HashedValue)
         assert isinstance(hashed, HashedValue)
 
 
@@ -147,7 +141,6 @@ class TestHMACSHA256Adapter:
 
     def test_compute_blind_index_string(self):
         result = HMACSHA256Adapter.compute_blind_index("test@example.com", self.TEST_KEY)
-        assert isinstance(result, BlindIndexValue)
         assert isinstance(result, BlindIndexValue)
         assert len(result) == 32
 
@@ -177,5 +170,3 @@ class TestArgon2BlindIndexAdapter:
         result = Argon2BlindIndexAdapter.compute_blind_index("test", self.TEST_KEY)
         double_indexed = Argon2BlindIndexAdapter.compute_blind_index(result, self.TEST_KEY)
         assert result == double_indexed
-
-

--- a/tests/unit/test_async_adapters.py
+++ b/tests/unit/test_async_adapters.py
@@ -15,7 +15,6 @@ class TestAsyncFernetAdapter:
         encrypted = await FernetAdapter.async_encrypt(plaintext)
 
         assert isinstance(encrypted, EncryptedValue)
-        assert isinstance(encrypted, EncryptedValue)
         assert encrypted != plaintext.encode("utf-8")
 
     @pytest.mark.asyncio
@@ -23,7 +22,6 @@ class TestAsyncFernetAdapter:
         plaintext = b"secret bytes"
         encrypted = await FernetAdapter.async_encrypt(plaintext)
 
-        assert isinstance(encrypted, EncryptedValue)
         assert isinstance(encrypted, EncryptedValue)
 
     @pytest.mark.asyncio
@@ -97,7 +95,6 @@ class TestAsyncArgon2Adapter:
         hashed = await Argon2Adapter.async_hash(value)
 
         assert isinstance(hashed, HashedValue)
-        assert isinstance(hashed, HashedValue)
         assert hashed != value.encode("utf-8")
 
     @pytest.mark.asyncio
@@ -105,7 +102,6 @@ class TestAsyncArgon2Adapter:
         value = b"password123"
         hashed = await Argon2Adapter.async_hash(value)
 
-        assert isinstance(hashed, HashedValue)
         assert isinstance(hashed, HashedValue)
 
     @pytest.mark.asyncio
@@ -135,7 +131,6 @@ class TestAsyncArgon2Adapter:
         hashed = await Argon2Adapter.async_hash(value)
 
         assert isinstance(hashed, HashedValue)
-        assert isinstance(hashed, HashedValue)
 
 
 class TestAsyncHMACSHA256Adapter:
@@ -146,7 +141,6 @@ class TestAsyncHMACSHA256Adapter:
     @pytest.mark.asyncio
     async def test_async_compute_blind_index_string(self):
         result = await HMACSHA256Adapter.async_compute_blind_index("test@example.com", self.TEST_KEY)
-        assert isinstance(result, BlindIndexValue)
         assert isinstance(result, BlindIndexValue)
         assert len(result) == 32
 

--- a/tests/unit/test_async_models.py
+++ b/tests/unit/test_async_models.py
@@ -404,11 +404,6 @@ class TestAsyncInitNestedModels:
         assert isinstance(user.addresses["work"][0].street, EncryptedValue)
 
 
-@pytest.fixture(autouse=True)
-def set_blind_index_key(monkeypatch):
-    monkeypatch.setattr(settings, "BLIND_INDEX_SECRET_KEY", "test-secret-key-for-async")
-
-
 class TestAsyncBlindIndexData:
     """Test async_blind_index_data method."""
 

--- a/tests/unit/test_blind_index_annotation.py
+++ b/tests/unit/test_blind_index_annotation.py
@@ -6,15 +6,6 @@ from pydantic_encryption import BaseModel, BlindIndex, BlindIndexMethod
 from pydantic_encryption.types import BlindIndexValue
 
 
-@pytest.fixture(autouse=True)
-def set_blind_index_key(monkeypatch):
-    """Set a test blind index secret key for all tests."""
-
-    from pydantic_encryption import config
-
-    monkeypatch.setattr(config.settings, "BLIND_INDEX_SECRET_KEY", "test-secret-key-for-annotation")
-
-
 class TestBlindIndexAnnotationHMAC:
     """Test BlindIndex annotation with HMAC-SHA256 in Pydantic models."""
 

--- a/tests/unit/test_sqlalchemy/test_blind_index.py
+++ b/tests/unit/test_sqlalchemy/test_blind_index.py
@@ -4,15 +4,6 @@ from pydantic_encryption.integrations.sqlalchemy.blind_index import SQLAlchemyBl
 from pydantic_encryption.types import BlindIndexMethod, BlindIndexValue
 
 
-@pytest.fixture(autouse=True)
-def set_blind_index_key(monkeypatch):
-    """Set a test blind index secret key for all tests."""
-
-    from pydantic_encryption.integrations.sqlalchemy import blind_index as blind_index_module
-
-    monkeypatch.setattr(blind_index_module.settings, "BLIND_INDEX_SECRET_KEY", "test-secret-key-for-blind-index")
-
-
 class TestSQLAlchemyBlindIndexValueHMAC:
     """Test SQLAlchemyBlindIndexValue with HMAC-SHA256 method."""
 
@@ -73,7 +64,6 @@ class TestSQLAlchemyBlindIndexValueHMAC:
     def test_process_result_value_returns_blind_index_value(self):
         test_bytes = b"\x01\x02\x03\x04" * 8
         result = self.type_adapter.process_result_value(test_bytes, None)
-        assert isinstance(result, BlindIndexValue)
         assert isinstance(result, BlindIndexValue)
         assert result == test_bytes
 

--- a/uv.lock
+++ b/uv.lock
@@ -1203,7 +1203,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-encryption"
-version = "0.10.1"
+version = "0.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },


### PR DESCRIPTION
Whole-repository refactor pass (slop removal, de-duplication, consistency), behavior preserved. Net −41 lines.

## Changes

**`pydantic_encryption/models/base.py`**
- Removed the no-op `BaseModel.get_annotated_fields` override — a pure pass-through to `super()` left over from an old type-narrowing shim; the MRO resolves to the same `SuperModelPydanticMixin` implementation.
- Import `Argon2Adapter` directly instead of reaching through `hashing.argon2.Argon2Adapter`, matching the canonical pattern in `integrations/sqlalchemy/hashing.py` (argon2-cffi is a required dependency and was already imported eagerly via the package `__init__`).

**`pydantic_encryption/integrations/sqlalchemy/bulk.py`**
- Extracted `pop_pending_rows()` so `decrypt_pending_fields` and `finalize_sqlalchemy_session` share the duplicated pop-and-flatten logic. The deliberate pop → commit → decrypt ordering from #27 is preserved (covered by `test_commits_before_running_bulk_decrypt`).
- Dropped the redundant empty-rows guards — `bulk_decrypt_entities` already no-ops on an empty input before resolving any backend.

**Tests**
- Deleted three per-module `set_blind_index_key` autouse fixtures (`test_blind_index_annotation.py`, `test_async_models.py`, `test_sqlalchemy/test_blind_index.py`) made redundant when the root `tests/conftest.py` started seeding `BLIND_INDEX_SECRET_KEY` (#29). No test asserts absolute digests, so the key value doesn't matter.
- Removed 14 accidental consecutive duplicate `assert isinstance(...)` lines (copy-paste artifacts from the `c92a0d2` assertion migration) across `test_adapters.py`, `test_async_adapters.py`, and `test_sqlalchemy/test_blind_index.py`.

**`uv.lock`** — synced the locked `pydantic-encryption` version with `pyproject.toml` (0.10.1 → 0.11.1).

## Evaluated and intentionally kept
- Adapter idempotent early-returns (`encrypt(already_encrypted)` returns input) — explicitly tested contract.
- `kms_kwargs()` runtime validation in the AWS adapter — reachable when the adapter is used without `ENCRYPTION_METHOD=aws`, so not a duplicate of the config validator.
- The sync/async method pairs in `SecureModel` and the per-class `BlindIndex` / `SQLAlchemyBlindIndexValue` normalization parameters — merging them would risk the public API and SQLAlchemy type cache-key generation for marginal gain.

## Verification
- 387 unit tests pass (`uv run pytest tests/unit`).
- Integration tests need Docker/Postgres, which isn't available in this environment — please let CI run them.

https://claude.ai/code/session_01TT4BY1xxoT27fQiRDJKTGe

---
_Generated by [Claude Code](https://claude.ai/code/session_01TT4BY1xxoT27fQiRDJKTGe)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical deduplication and test cleanup; crypto/session finalize paths rely on existing no-op and ordering guarantees covered by unit tests.
> 
> **Overview**
> Cleanup refactor across the library and unit tests with **no intended behavior change** (net −41 lines).
> 
> **SQLAlchemy bulk decrypt:** Adds **`pop_pending_rows()`** so `decrypt_pending_fields` and `finalize_sqlalchemy_session` share one pop-and-flatten path; redundant empty-list guards are removed because **`bulk_decrypt_entities`** already no-ops on empty input. Commit-then-decrypt ordering is unchanged.
> 
> **Models:** Drops the pass-through **`BaseModel.get_annotated_fields`** override and imports **`Argon2Adapter`** directly for sync/async hashing instead of going through **`hashing.argon2`**.
> 
> **Tests:** Removes three redundant per-module **`set_blind_index_key`** autouse fixtures (root **`tests/conftest.py`** already sets **`BLIND_INDEX_SECRET_KEY`**), strips duplicate **`assert isinstance`** lines, and bumps **`uv.lock`** for **`pydantic-encryption`** 0.10.1 → 0.11.1.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 453729f274ed62fa8e8b2634699d6e56085db4cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->