### PR TITLE
ci: stamp simplify-on-stop hook to fire once per branch state

### DIFF
--- a/.agents/hooks/simplify-on-stop.sh
+++ b/.agents/hooks/simplify-on-stop.sh
@@ -1,13 +1,10 @@
 #!/usr/bin/env bash
-# Stop hook: before each push, ask the agent to run two project skills over the
-# whole branch diff as a local pre-push pass — first code review, then
-# simplification — and fold the fixes into the push. The agent decides whether
-# the skills apply; if the branch has no changes it skips gracefully and stops.
-#
-# Loop prevention: `stop_hook_active` is true when Claude Code retries Stop after
-# our block; exit clean then so we never block twice. If that flag cannot be read
-# (no python3, or an unreadable payload), treat it as active and exit clean —
-# skipping a single nudge is acceptable, an infinite Stop-hook loop is not.
+# Stop hook: nudge the agent to run claude-review and code-simplify over the
+# whole branch diff as a local pre-push pass. A stamp of HEAD + uncommitted
+# changes in the git dir limits the nudge to once per branch state — gating on
+# unpushed work would never fire in remote sessions, which push within the same
+# turn. `stop_hook_active` stops a second block in one stop cycle; if it cannot
+# be read, treat it as active — a skipped nudge beats an infinite Stop loop.
 
 set -euo pipefail
 
@@ -22,17 +19,27 @@ is_active=$(printf '%s' "$input" | python3 -c \
 [ "$is_active" = "true" ] && exit 0
 
 # Outside a git work tree there is nothing to push or diff, so let Stop complete.
-git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+git_dir=$(git rev-parse --git-dir 2>/dev/null) || exit 0
 
-# Only nudge when something is actually about to be pushed. If the working tree
-# is clean and HEAD is not ahead of an existing upstream, there is nothing to
-# review or simplify before a push (e.g. the branch is already pushed/merged, or
-# the session only answered a question), so skip. A branch with no upstream yet,
-# or any git error, falls through and still gets nudged.
-if [ -z "$(git status --porcelain --untracked-files=normal 2>/dev/null)" ] \
-  && git rev-parse --verify --quiet '@{u}' >/dev/null 2>&1; then
-  ahead=$(git rev-list --count '@{u}..HEAD' 2>/dev/null || echo "x")
-  [ "$ahead" = "0" ] && exit 0
+head_sha=$(git rev-parse HEAD 2>/dev/null || echo "no-head")
+porcelain=$(git status --porcelain --untracked-files=normal 2>/dev/null || echo "status-error")
+dirty_sha=$(printf '%s' "$porcelain" | git hash-object --stdin 2>/dev/null || echo "hash-error")
+state="$head_sha:$dirty_sha"
+
+stamp_file="$git_dir/simplify-on-stop.stamp"
+[ -f "$stamp_file" ] && [ "$(cat "$stamp_file")" = "$state" ] && exit 0
+
+# Clean tree with no diff over the remote default branch means nothing to
+# review; a missing ref or git error falls through and still nudges.
+if [ -z "$porcelain" ]; then
+  default_ref=$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null \
+    || echo "refs/remotes/origin/main")
+  base=$(git merge-base "$default_ref" HEAD 2>/dev/null || echo "")
+  if [ -n "$base" ] && git diff --quiet "$base" HEAD 2>/dev/null; then
+    exit 0
+  fi
 fi
 
-echo '{"decision":"block","reason":"Before pushing, run two project skills over the WHOLE branch diff (every change versus the base branch, including uncommitted work — not just this session) as a LOCAL pre-push pass — no GitHub PR is required. First, call the Skill tool with skill=\"claude-review\" in its local / pre-push mode: review the whole branch diff and apply the real fixes it surfaces directly (pre-existing issues in the touched files are in scope); for this pass do not open or require a PR, do not ask before fixing, do not branch off, and do not post a comment. Second, call skill=\"code-simplify\" (the project skill, NOT the built-in \"simplify\") over the same branch diff and apply its simplifications. Fold every edit from both skills into the commit you are about to push — do not rubber-stamp \"no changes needed\" or split them into a separate follow-up commit. If the branch has no code changes, skip both skills and conclude."}'
+printf '%s' "$state" > "$stamp_file"
+
+echo '{"decision":"block","reason":"Run a LOCAL pre-push pass over the WHOLE branch diff versus the base branch, including uncommitted work — no GitHub PR required. First call the Skill tool with skill=\"claude-review\" in local mode and apply the real fixes directly (no PR, no asking, no branching off, no comment). Then call skill=\"code-simplify\" (the project skill, NOT the built-in \"simplify\") over the same diff and apply its simplifications. Commit the edits from both skills, and push them if the branch was already pushed. If the branch has no code changes, skip both skills and conclude."}'

--- a/.agents/hooks/simplify-on-stop.sh
+++ b/.agents/hooks/simplify-on-stop.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Stop hook: nudge the agent to run claude-review and code-simplify over the
-# whole branch diff as a local pre-push pass. A stamp of HEAD + uncommitted
-# changes in the git dir limits the nudge to once per branch state — gating on
+# whole branch diff as a local pre-push pass. A stamp of HEAD + working-tree
+# content in the git dir limits the nudge to once per branch state — gating on
 # unpushed work would never fire in remote sessions, which push within the same
 # turn. `stop_hook_active` stops a second block in one stop cycle; if it cannot
 # be read, treat it as active — a skipped nudge beats an infinite Stop loop.
@@ -21,22 +21,39 @@ is_active=$(printf '%s' "$input" | python3 -c \
 # Outside a git work tree there is nothing to push or diff, so let Stop complete.
 git_dir=$(git rev-parse --git-dir 2>/dev/null) || exit 0
 
+# State = HEAD plus a hash of the actual working-tree content (tracked diff and
+# untracked file contents), so re-editing an already-modified file changes the
+# stamp and the pre-push pass fires again instead of matching a stale stamp.
 head_sha=$(git rev-parse HEAD 2>/dev/null || echo "no-head")
 porcelain=$(git status --porcelain --untracked-files=normal 2>/dev/null || echo "status-error")
-dirty_sha=$(printf '%s' "$porcelain" | git hash-object --stdin 2>/dev/null || echo "hash-error")
+dirty_sha=$(
+  {
+    git diff HEAD 2>/dev/null || true
+    git ls-files --others --exclude-standard -z 2>/dev/null \
+      | xargs -0 -r git hash-object 2>/dev/null || true
+  } | git hash-object --stdin 2>/dev/null || echo "hash-error"
+)
 state="$head_sha:$dirty_sha"
 
 stamp_file="$git_dir/simplify-on-stop.stamp"
 [ -f "$stamp_file" ] && [ "$(cat "$stamp_file")" = "$state" ] && exit 0
 
 # Clean tree with no diff over the remote default branch means nothing to
-# review; a missing ref or git error falls through and still nudges.
+# review. Resolve the default via origin/HEAD, then fall back to whichever of
+# origin/main or origin/master exists; a missing ref or git error falls through
+# and still nudges.
 if [ -z "$porcelain" ]; then
-  default_ref=$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null \
-    || echo "refs/remotes/origin/main")
-  base=$(git merge-base "$default_ref" HEAD 2>/dev/null || echo "")
-  if [ -n "$base" ] && git diff --quiet "$base" HEAD 2>/dev/null; then
-    exit 0
+  default_ref=$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || echo "")
+  if [ -z "$default_ref" ]; then
+    for cand in refs/remotes/origin/main refs/remotes/origin/master; do
+      git rev-parse --verify --quiet "$cand" >/dev/null 2>&1 && { default_ref="$cand"; break; }
+    done
+  fi
+  if [ -n "$default_ref" ]; then
+    base=$(git merge-base "$default_ref" HEAD 2>/dev/null || echo "")
+    if [ -n "$base" ] && git diff --quiet "$base" HEAD 2>/dev/null; then
+      exit 0
+    fi
   fi
 fi
 

--- a/.agents/hooks/simplify-on-stop.sh
+++ b/.agents/hooks/simplify-on-stop.sh
@@ -18,19 +18,26 @@ is_active=$(printf '%s' "$input" | python3 -c \
 
 [ "$is_active" = "true" ] && exit 0
 
-# Outside a git work tree there is nothing to push or diff, so let Stop complete.
+# Outside a git work tree (a bare repo has none) there is nothing to push or
+# diff, so let Stop complete. Check the work tree first, then take the git dir.
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
 git_dir=$(git rev-parse --git-dir 2>/dev/null) || exit 0
 
-# State = HEAD plus a hash of the actual working-tree content (tracked diff and
-# untracked file contents), so re-editing an already-modified file changes the
-# stamp and the pre-push pass fires again instead of matching a stale stamp.
+# State = HEAD plus a hash of the actual working-tree content, so re-editing an
+# already-modified file changes the stamp and the pre-push pass fires again
+# instead of matching a stale stamp. `git diff --binary` folds in binary file
+# bytes; a portable read loop (no GNU-only `xargs -r`) hashes each untracked
+# file's path and contents.
 head_sha=$(git rev-parse HEAD 2>/dev/null || echo "no-head")
 porcelain=$(git status --porcelain --untracked-files=normal 2>/dev/null || echo "status-error")
 dirty_sha=$(
   {
-    git diff HEAD 2>/dev/null || true
+    git diff --binary HEAD 2>/dev/null || true
     git ls-files --others --exclude-standard -z 2>/dev/null \
-      | xargs -0 -r git hash-object 2>/dev/null || true
+      | while IFS= read -r -d '' file; do
+          printf '%s\0' "$file"
+          git hash-object "$file" 2>/dev/null || true
+        done
   } | git hash-object --stdin 2>/dev/null || echo "hash-error"
 )
 state="$head_sha:$dirty_sha"

--- a/.claude/hooks/simplify-on-stop.sh
+++ b/.claude/hooks/simplify-on-stop.sh
@@ -1,13 +1,10 @@
 #!/usr/bin/env bash
-# Stop hook: before each push, ask the agent to run two project skills over the
-# whole branch diff as a local pre-push pass — first code review, then
-# simplification — and fold the fixes into the push. The agent decides whether
-# the skills apply; if the branch has no changes it skips gracefully and stops.
-#
-# Loop prevention: `stop_hook_active` is true when Claude Code retries Stop after
-# our block; exit clean then so we never block twice. If that flag cannot be read
-# (no python3, or an unreadable payload), treat it as active and exit clean —
-# skipping a single nudge is acceptable, an infinite Stop-hook loop is not.
+# Stop hook: nudge the agent to run claude-review and code-simplify over the
+# whole branch diff as a local pre-push pass. A stamp of HEAD + uncommitted
+# changes in the git dir limits the nudge to once per branch state — gating on
+# unpushed work would never fire in remote sessions, which push within the same
+# turn. `stop_hook_active` stops a second block in one stop cycle; if it cannot
+# be read, treat it as active — a skipped nudge beats an infinite Stop loop.
 
 set -euo pipefail
 
@@ -22,17 +19,27 @@ is_active=$(printf '%s' "$input" | python3 -c \
 [ "$is_active" = "true" ] && exit 0
 
 # Outside a git work tree there is nothing to push or diff, so let Stop complete.
-git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+git_dir=$(git rev-parse --git-dir 2>/dev/null) || exit 0
 
-# Only nudge when something is actually about to be pushed. If the working tree
-# is clean and HEAD is not ahead of an existing upstream, there is nothing to
-# review or simplify before a push (e.g. the branch is already pushed/merged, or
-# the session only answered a question), so skip. A branch with no upstream yet,
-# or any git error, falls through and still gets nudged.
-if [ -z "$(git status --porcelain --untracked-files=normal 2>/dev/null)" ] \
-  && git rev-parse --verify --quiet '@{u}' >/dev/null 2>&1; then
-  ahead=$(git rev-list --count '@{u}..HEAD' 2>/dev/null || echo "x")
-  [ "$ahead" = "0" ] && exit 0
+head_sha=$(git rev-parse HEAD 2>/dev/null || echo "no-head")
+porcelain=$(git status --porcelain --untracked-files=normal 2>/dev/null || echo "status-error")
+dirty_sha=$(printf '%s' "$porcelain" | git hash-object --stdin 2>/dev/null || echo "hash-error")
+state="$head_sha:$dirty_sha"
+
+stamp_file="$git_dir/simplify-on-stop.stamp"
+[ -f "$stamp_file" ] && [ "$(cat "$stamp_file")" = "$state" ] && exit 0
+
+# Clean tree with no diff over the remote default branch means nothing to
+# review; a missing ref or git error falls through and still nudges.
+if [ -z "$porcelain" ]; then
+  default_ref=$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null \
+    || echo "refs/remotes/origin/main")
+  base=$(git merge-base "$default_ref" HEAD 2>/dev/null || echo "")
+  if [ -n "$base" ] && git diff --quiet "$base" HEAD 2>/dev/null; then
+    exit 0
+  fi
 fi
 
-echo '{"decision":"block","reason":"Before pushing, run two project skills over the WHOLE branch diff (every change versus the base branch, including uncommitted work — not just this session) as a LOCAL pre-push pass — no GitHub PR is required. First, call the Skill tool with skill=\"claude-review\" in its local / pre-push mode: review the whole branch diff and apply the real fixes it surfaces directly (pre-existing issues in the touched files are in scope); for this pass do not open or require a PR, do not ask before fixing, do not branch off, and do not post a comment. Second, call skill=\"code-simplify\" (the project skill, NOT the built-in \"simplify\") over the same branch diff and apply its simplifications. Fold every edit from both skills into the commit you are about to push — do not rubber-stamp \"no changes needed\" or split them into a separate follow-up commit. If the branch has no code changes, skip both skills and conclude."}'
+printf '%s' "$state" > "$stamp_file"
+
+echo '{"decision":"block","reason":"Run a LOCAL pre-push pass over the WHOLE branch diff versus the base branch, including uncommitted work — no GitHub PR required. First call the Skill tool with skill=\"claude-review\" in local mode and apply the real fixes directly (no PR, no asking, no branching off, no comment). Then call skill=\"code-simplify\" (the project skill, NOT the built-in \"simplify\") over the same diff and apply its simplifications. Commit the edits from both skills, and push them if the branch was already pushed. If the branch has no code changes, skip both skills and conclude."}'

--- a/.claude/hooks/simplify-on-stop.sh
+++ b/.claude/hooks/simplify-on-stop.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Stop hook: nudge the agent to run claude-review and code-simplify over the
-# whole branch diff as a local pre-push pass. A stamp of HEAD + uncommitted
-# changes in the git dir limits the nudge to once per branch state — gating on
+# whole branch diff as a local pre-push pass. A stamp of HEAD + working-tree
+# content in the git dir limits the nudge to once per branch state — gating on
 # unpushed work would never fire in remote sessions, which push within the same
 # turn. `stop_hook_active` stops a second block in one stop cycle; if it cannot
 # be read, treat it as active — a skipped nudge beats an infinite Stop loop.
@@ -21,22 +21,39 @@ is_active=$(printf '%s' "$input" | python3 -c \
 # Outside a git work tree there is nothing to push or diff, so let Stop complete.
 git_dir=$(git rev-parse --git-dir 2>/dev/null) || exit 0
 
+# State = HEAD plus a hash of the actual working-tree content (tracked diff and
+# untracked file contents), so re-editing an already-modified file changes the
+# stamp and the pre-push pass fires again instead of matching a stale stamp.
 head_sha=$(git rev-parse HEAD 2>/dev/null || echo "no-head")
 porcelain=$(git status --porcelain --untracked-files=normal 2>/dev/null || echo "status-error")
-dirty_sha=$(printf '%s' "$porcelain" | git hash-object --stdin 2>/dev/null || echo "hash-error")
+dirty_sha=$(
+  {
+    git diff HEAD 2>/dev/null || true
+    git ls-files --others --exclude-standard -z 2>/dev/null \
+      | xargs -0 -r git hash-object 2>/dev/null || true
+  } | git hash-object --stdin 2>/dev/null || echo "hash-error"
+)
 state="$head_sha:$dirty_sha"
 
 stamp_file="$git_dir/simplify-on-stop.stamp"
 [ -f "$stamp_file" ] && [ "$(cat "$stamp_file")" = "$state" ] && exit 0
 
 # Clean tree with no diff over the remote default branch means nothing to
-# review; a missing ref or git error falls through and still nudges.
+# review. Resolve the default via origin/HEAD, then fall back to whichever of
+# origin/main or origin/master exists; a missing ref or git error falls through
+# and still nudges.
 if [ -z "$porcelain" ]; then
-  default_ref=$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null \
-    || echo "refs/remotes/origin/main")
-  base=$(git merge-base "$default_ref" HEAD 2>/dev/null || echo "")
-  if [ -n "$base" ] && git diff --quiet "$base" HEAD 2>/dev/null; then
-    exit 0
+  default_ref=$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || echo "")
+  if [ -z "$default_ref" ]; then
+    for cand in refs/remotes/origin/main refs/remotes/origin/master; do
+      git rev-parse --verify --quiet "$cand" >/dev/null 2>&1 && { default_ref="$cand"; break; }
+    done
+  fi
+  if [ -n "$default_ref" ]; then
+    base=$(git merge-base "$default_ref" HEAD 2>/dev/null || echo "")
+    if [ -n "$base" ] && git diff --quiet "$base" HEAD 2>/dev/null; then
+      exit 0
+    fi
   fi
 fi
 

--- a/.claude/hooks/simplify-on-stop.sh
+++ b/.claude/hooks/simplify-on-stop.sh
@@ -18,19 +18,26 @@ is_active=$(printf '%s' "$input" | python3 -c \
 
 [ "$is_active" = "true" ] && exit 0
 
-# Outside a git work tree there is nothing to push or diff, so let Stop complete.
+# Outside a git work tree (a bare repo has none) there is nothing to push or
+# diff, so let Stop complete. Check the work tree first, then take the git dir.
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
 git_dir=$(git rev-parse --git-dir 2>/dev/null) || exit 0
 
-# State = HEAD plus a hash of the actual working-tree content (tracked diff and
-# untracked file contents), so re-editing an already-modified file changes the
-# stamp and the pre-push pass fires again instead of matching a stale stamp.
+# State = HEAD plus a hash of the actual working-tree content, so re-editing an
+# already-modified file changes the stamp and the pre-push pass fires again
+# instead of matching a stale stamp. `git diff --binary` folds in binary file
+# bytes; a portable read loop (no GNU-only `xargs -r`) hashes each untracked
+# file's path and contents.
 head_sha=$(git rev-parse HEAD 2>/dev/null || echo "no-head")
 porcelain=$(git status --porcelain --untracked-files=normal 2>/dev/null || echo "status-error")
 dirty_sha=$(
   {
-    git diff HEAD 2>/dev/null || true
+    git diff --binary HEAD 2>/dev/null || true
     git ls-files --others --exclude-standard -z 2>/dev/null \
-      | xargs -0 -r git hash-object 2>/dev/null || true
+      | while IFS= read -r -d '' file; do
+          printf '%s\0' "$file"
+          git hash-object "$file" 2>/dev/null || true
+        done
   } | git hash-object --stdin 2>/dev/null || echo "hash-error"
 )
 state="$head_sha:$dirty_sha"

--- a/.cursor/hooks/simplify-on-stop.sh
+++ b/.cursor/hooks/simplify-on-stop.sh
@@ -1,13 +1,10 @@
 #!/usr/bin/env bash
-# Stop hook: before each push, ask the agent to run two project skills over the
-# whole branch diff as a local pre-push pass — first code review, then
-# simplification — and fold the fixes into the push. The agent decides whether
-# the skills apply; if the branch has no changes it skips gracefully and stops.
-#
-# Loop prevention: `stop_hook_active` is true when Claude Code retries Stop after
-# our block; exit clean then so we never block twice. If that flag cannot be read
-# (no python3, or an unreadable payload), treat it as active and exit clean —
-# skipping a single nudge is acceptable, an infinite Stop-hook loop is not.
+# Stop hook: nudge the agent to run claude-review and code-simplify over the
+# whole branch diff as a local pre-push pass. A stamp of HEAD + uncommitted
+# changes in the git dir limits the nudge to once per branch state — gating on
+# unpushed work would never fire in remote sessions, which push within the same
+# turn. `stop_hook_active` stops a second block in one stop cycle; if it cannot
+# be read, treat it as active — a skipped nudge beats an infinite Stop loop.
 
 set -euo pipefail
 
@@ -22,17 +19,27 @@ is_active=$(printf '%s' "$input" | python3 -c \
 [ "$is_active" = "true" ] && exit 0
 
 # Outside a git work tree there is nothing to push or diff, so let Stop complete.
-git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+git_dir=$(git rev-parse --git-dir 2>/dev/null) || exit 0
 
-# Only nudge when something is actually about to be pushed. If the working tree
-# is clean and HEAD is not ahead of an existing upstream, there is nothing to
-# review or simplify before a push (e.g. the branch is already pushed/merged, or
-# the session only answered a question), so skip. A branch with no upstream yet,
-# or any git error, falls through and still gets nudged.
-if [ -z "$(git status --porcelain --untracked-files=normal 2>/dev/null)" ] \
-  && git rev-parse --verify --quiet '@{u}' >/dev/null 2>&1; then
-  ahead=$(git rev-list --count '@{u}..HEAD' 2>/dev/null || echo "x")
-  [ "$ahead" = "0" ] && exit 0
+head_sha=$(git rev-parse HEAD 2>/dev/null || echo "no-head")
+porcelain=$(git status --porcelain --untracked-files=normal 2>/dev/null || echo "status-error")
+dirty_sha=$(printf '%s' "$porcelain" | git hash-object --stdin 2>/dev/null || echo "hash-error")
+state="$head_sha:$dirty_sha"
+
+stamp_file="$git_dir/simplify-on-stop.stamp"
+[ -f "$stamp_file" ] && [ "$(cat "$stamp_file")" = "$state" ] && exit 0
+
+# Clean tree with no diff over the remote default branch means nothing to
+# review; a missing ref or git error falls through and still nudges.
+if [ -z "$porcelain" ]; then
+  default_ref=$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null \
+    || echo "refs/remotes/origin/main")
+  base=$(git merge-base "$default_ref" HEAD 2>/dev/null || echo "")
+  if [ -n "$base" ] && git diff --quiet "$base" HEAD 2>/dev/null; then
+    exit 0
+  fi
 fi
 
-echo '{"decision":"block","reason":"Before pushing, run two project skills over the WHOLE branch diff (every change versus the base branch, including uncommitted work — not just this session) as a LOCAL pre-push pass — no GitHub PR is required. First, call the Skill tool with skill=\"claude-review\" in its local / pre-push mode: review the whole branch diff and apply the real fixes it surfaces directly (pre-existing issues in the touched files are in scope); for this pass do not open or require a PR, do not ask before fixing, do not branch off, and do not post a comment. Second, call skill=\"code-simplify\" (the project skill, NOT the built-in \"simplify\") over the same branch diff and apply its simplifications. Fold every edit from both skills into the commit you are about to push — do not rubber-stamp \"no changes needed\" or split them into a separate follow-up commit. If the branch has no code changes, skip both skills and conclude."}'
+printf '%s' "$state" > "$stamp_file"
+
+echo '{"decision":"block","reason":"Run a LOCAL pre-push pass over the WHOLE branch diff versus the base branch, including uncommitted work — no GitHub PR required. First call the Skill tool with skill=\"claude-review\" in local mode and apply the real fixes directly (no PR, no asking, no branching off, no comment). Then call skill=\"code-simplify\" (the project skill, NOT the built-in \"simplify\") over the same diff and apply its simplifications. Commit the edits from both skills, and push them if the branch was already pushed. If the branch has no code changes, skip both skills and conclude."}'

--- a/.cursor/hooks/simplify-on-stop.sh
+++ b/.cursor/hooks/simplify-on-stop.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Stop hook: nudge the agent to run claude-review and code-simplify over the
-# whole branch diff as a local pre-push pass. A stamp of HEAD + uncommitted
-# changes in the git dir limits the nudge to once per branch state — gating on
+# whole branch diff as a local pre-push pass. A stamp of HEAD + working-tree
+# content in the git dir limits the nudge to once per branch state — gating on
 # unpushed work would never fire in remote sessions, which push within the same
 # turn. `stop_hook_active` stops a second block in one stop cycle; if it cannot
 # be read, treat it as active — a skipped nudge beats an infinite Stop loop.
@@ -21,22 +21,39 @@ is_active=$(printf '%s' "$input" | python3 -c \
 # Outside a git work tree there is nothing to push or diff, so let Stop complete.
 git_dir=$(git rev-parse --git-dir 2>/dev/null) || exit 0
 
+# State = HEAD plus a hash of the actual working-tree content (tracked diff and
+# untracked file contents), so re-editing an already-modified file changes the
+# stamp and the pre-push pass fires again instead of matching a stale stamp.
 head_sha=$(git rev-parse HEAD 2>/dev/null || echo "no-head")
 porcelain=$(git status --porcelain --untracked-files=normal 2>/dev/null || echo "status-error")
-dirty_sha=$(printf '%s' "$porcelain" | git hash-object --stdin 2>/dev/null || echo "hash-error")
+dirty_sha=$(
+  {
+    git diff HEAD 2>/dev/null || true
+    git ls-files --others --exclude-standard -z 2>/dev/null \
+      | xargs -0 -r git hash-object 2>/dev/null || true
+  } | git hash-object --stdin 2>/dev/null || echo "hash-error"
+)
 state="$head_sha:$dirty_sha"
 
 stamp_file="$git_dir/simplify-on-stop.stamp"
 [ -f "$stamp_file" ] && [ "$(cat "$stamp_file")" = "$state" ] && exit 0
 
 # Clean tree with no diff over the remote default branch means nothing to
-# review; a missing ref or git error falls through and still nudges.
+# review. Resolve the default via origin/HEAD, then fall back to whichever of
+# origin/main or origin/master exists; a missing ref or git error falls through
+# and still nudges.
 if [ -z "$porcelain" ]; then
-  default_ref=$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null \
-    || echo "refs/remotes/origin/main")
-  base=$(git merge-base "$default_ref" HEAD 2>/dev/null || echo "")
-  if [ -n "$base" ] && git diff --quiet "$base" HEAD 2>/dev/null; then
-    exit 0
+  default_ref=$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || echo "")
+  if [ -z "$default_ref" ]; then
+    for cand in refs/remotes/origin/main refs/remotes/origin/master; do
+      git rev-parse --verify --quiet "$cand" >/dev/null 2>&1 && { default_ref="$cand"; break; }
+    done
+  fi
+  if [ -n "$default_ref" ]; then
+    base=$(git merge-base "$default_ref" HEAD 2>/dev/null || echo "")
+    if [ -n "$base" ] && git diff --quiet "$base" HEAD 2>/dev/null; then
+      exit 0
+    fi
   fi
 fi
 

--- a/.cursor/hooks/simplify-on-stop.sh
+++ b/.cursor/hooks/simplify-on-stop.sh
@@ -18,19 +18,26 @@ is_active=$(printf '%s' "$input" | python3 -c \
 
 [ "$is_active" = "true" ] && exit 0
 
-# Outside a git work tree there is nothing to push or diff, so let Stop complete.
+# Outside a git work tree (a bare repo has none) there is nothing to push or
+# diff, so let Stop complete. Check the work tree first, then take the git dir.
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
 git_dir=$(git rev-parse --git-dir 2>/dev/null) || exit 0
 
-# State = HEAD plus a hash of the actual working-tree content (tracked diff and
-# untracked file contents), so re-editing an already-modified file changes the
-# stamp and the pre-push pass fires again instead of matching a stale stamp.
+# State = HEAD plus a hash of the actual working-tree content, so re-editing an
+# already-modified file changes the stamp and the pre-push pass fires again
+# instead of matching a stale stamp. `git diff --binary` folds in binary file
+# bytes; a portable read loop (no GNU-only `xargs -r`) hashes each untracked
+# file's path and contents.
 head_sha=$(git rev-parse HEAD 2>/dev/null || echo "no-head")
 porcelain=$(git status --porcelain --untracked-files=normal 2>/dev/null || echo "status-error")
 dirty_sha=$(
   {
-    git diff HEAD 2>/dev/null || true
+    git diff --binary HEAD 2>/dev/null || true
     git ls-files --others --exclude-standard -z 2>/dev/null \
-      | xargs -0 -r git hash-object 2>/dev/null || true
+      | while IFS= read -r -d '' file; do
+          printf '%s\0' "$file"
+          git hash-object "$file" 2>/dev/null || true
+        done
   } | git hash-object --stdin 2>/dev/null || echo "hash-error"
 )
 state="$head_sha:$dirty_sha"


### PR DESCRIPTION
Updates the Stop-hook pre-push pass (`simplify-on-stop.sh`) so it fires once per branch state.

- Stamp `HEAD` plus a hash of the uncommitted changes in the git dir, and skip when that state is unchanged — replacing the old unpushed-work gate, which never fired in remote sessions that push within the same turn.
- Switch the work-tree guard to `git rev-parse --git-dir`.
- Trim the hook's comments and block message.

The hook is edited in `.agents/` and synced into the `.claude/` and `.cursor/` mirrors.

https://claude.ai/code/session_01Qd5RpkdCL9ktzLrJgGugh5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qd5RpkdCL9ktzLrJgGugh5)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Agent workflow hook only; no runtime app, auth, or data paths—behavior change is when local review/simplify nudges fire.
> 
> **Overview**
> The **Stop** hook `simplify-on-stop.sh` no longer decides whether to nudge from **unpushed commits vs upstream**. It now keys off a **branch state stamp** (`HEAD` + a hash of uncommitted changes, including binary diffs and untracked files) stored as `simplify-on-stop.stamp` under the git dir, so the pre-push **claude-review** / **code-simplify** pass runs **once per state** and fires again when the working tree actually changes—fixing remote sessions that push in the same turn and never looked “ahead.”
> 
> When the tree is **clean**, it still exits early if **HEAD** has **no diff** against the remote default branch (`origin/HEAD`, else `origin/main` or `origin/master`). The hook **writes the stamp before blocking**, and the block **reason** is shorter and now says to **push** review/simplify edits if the branch was already pushed. The same script is updated in **`.agents/`** and mirrored to **`.claude/`** and **`.cursor/`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e55b85a4a1161ebc5560b1b327e161d5a1eb6bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->