### PR TITLE
ci: add Claude review routine workflow on PR open/commit

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,55 @@
+name: Claude Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+
+# One in-flight fire per PR; a newer commit cancels a superseded run.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  fire-review-routine:
+    name: Fire Claude review routine
+    if: >-
+      ${{ github.event.pull_request.head.repo.full_name == github.repository
+          && github.event.sender.type != 'Bot'
+          && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fire routine
+        env:
+          CLAUDE_REVIEW_ROUTINE_API_KEY: ${{ secrets.CLAUDE_REVIEW_ROUTINE_API_KEY }}
+          CLAUDE_REVIEW_ROUTINE_ID: ${{ secrets.CLAUDE_REVIEW_ROUTINE_ID }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          if [ -z "$CLAUDE_REVIEW_ROUTINE_API_KEY" ] || [ -z "$CLAUDE_REVIEW_ROUTINE_ID" ]; then
+            echo "CLAUDE_REVIEW_ROUTINE_API_KEY or CLAUDE_REVIEW_ROUTINE_ID is unset; skipping."
+            exit 0
+          fi
+
+          payload=$(jq -n \
+            --arg repo "$REPO" \
+            --arg num "$PR_NUMBER" \
+            --arg url "$PR_URL" \
+            --arg ref "$HEAD_REF" \
+            --arg author "$PR_AUTHOR" \
+            --arg sha "$HEAD_SHA" \
+            '{text: "Review pull request #\($num) (\($url)) in repo \($repo), on branch \($ref), opened by \($author), triggered by commit \($sha)."}')
+
+          curl --fail-with-body -sS -X POST \
+            "https://api.anthropic.com/v1/claude_code/routines/${CLAUDE_REVIEW_ROUTINE_ID}/fire" \
+            -H "Authorization: Bearer $CLAUDE_REVIEW_ROUTINE_API_KEY" \
+            -H "anthropic-version: 2023-06-01" \
+            -H "anthropic-beta: experimental-cc-routine-2026-04-01" \
+            -H "Content-Type: application/json" \
+            -d "$payload"


### PR DESCRIPTION
Adds `.github/workflows/claude-review.yml`. On `pull_request` `opened`/`synchronize`, it fires the configured Claude Code review routine via the Anthropic API (`POST /v1/claude_code/routines/${CLAUDE_REVIEW_ROUTINE_ID}/fire`).

Guardrails:
- **Skips if unconfigured** — exits cleanly when the `CLAUDE_REVIEW_ROUTINE_API_KEY` or `CLAUDE_REVIEW_ROUTINE_ID` secret is unset.
- **Skips bot-authored events** (`github.event.sender.type != 'Bot'`).
- **Maintainers only** — runs only when the PR author's association is `OWNER`/`MEMBER`/`COLLABORATOR`, so external users can't consume the API key (fork PRs also don't receive secrets on `pull_request`).

The fired routine receives a `text` turn with context: repo, PR number/URL, branch, author, and the triggering commit SHA.

https://claude.ai/code/session_01Qd5RpkdCL9ktzLrJgGugh5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qd5RpkdCL9ktzLrJgGugh5)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only addition with read permissions and secret-gated API calls; no application or runtime behavior changes.
> 
> **Overview**
> Adds **`.github/workflows/claude-review.yml`**, a new GitHub Actions workflow that triggers on pull request **opened** and **synchronize** events.
> 
> When secrets are configured, the job **POSTs** to Anthropic’s Claude Code **routines fire** API with a short natural-language prompt (repo, PR number/URL, branch, author, head SHA). **Concurrency** is scoped per PR with **cancel-in-progress** so only the latest push runs.
> 
> **Guardrails:** read-only **`contents`** permission; skips if API key or routine ID secrets are missing (exit 0); runs only for same-repo PRs, non-bot senders, and authors with **OWNER/MEMBER/COLLABORATOR** association.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 178c9100304be20c8b2b773ecfda89178c4083cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->