### PR TITLE
Tune code-review: diff-only scope, cap Low findings

### DIFF
--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: code-review
-description: Review a GitHub pull request with parallel specialized agents and post inline review comments rated by severity. Surfaces every valid issue; does not fix anything. Use when asked to review a PR or run /code-review.
+description: Review a GitHub pull request with parallel specialized agents and post inline review comments rated by severity. Reviews the PR's changed lines and caps minor nitpicks; does not fix anything. Use when asked to review a PR or run /code-review.
 ---
 
 # Code Review
 
-Review a GitHub pull request with parallel specialized agents and post the findings as **inline review comments**, each rated by severity. Surface every valid issue — do not fix anything.
+Review a GitHub pull request with parallel specialized agents and post the findings as **inline review comments**, each rated by severity. Surface real issues, not nitpicks — do not fix anything.
 
-**Scope — pre-existing issues are in scope.** Do not limit the review to the lines this PR changed. Real bugs and project-rule violations that already existed in the touched files, or that the PR did not introduce, are within scope. Never dismiss a finding solely because it predates this PR.
+**Scope — review only what this PR changes.** Limit the review to the lines this PR adds or modifies. Every finding must anchor to a line in the diff; do not go hunting for pre-existing problems in untouched code. If a real issue sits on a line the PR did not touch — even in a file the PR edited — leave it out.
 
 ## GitHub tools — pick by runner
 
@@ -31,17 +31,17 @@ Then check eligibility (delegate to a sub-agent when sub-agents are available): 
 
 ## Step 3 — Review (parallel reviewers)
 
-Launch the following review agents in parallel (or sequentially in this thread if sub-agents are unavailable). Each reads the changed files and returns a flat list of findings — each with its **file path, line number, and diff side** (`RIGHT` for an added/current line, `LEFT` for a removed line using the base-side line number, or `off-diff` for a line the PR did not touch) plus the reason it was flagged:
+Launch the following review agents in parallel (or sequentially in this thread if sub-agents are unavailable). Each reads the changed files and returns a flat list of findings — each with its **file path, line number, and diff side** (`RIGHT` for an added/current line, or `LEFT` for a removed line using the base-side line number) plus the reason it was flagged:
 
 - Agent #1 (rules): audit the changes for compliance with the project rule files from Step 2. The rules are guidance for code generation, so not all apply during review.
-- Agent #2 (bugs): scan for real defects; ignore likely false positives. Pre-existing bugs in the touched files are in scope.
-- Agent #3 (history): read git blame and history of the changed files; flag bugs that only make sense in light of that history.
-- Agent #4 (prior PRs): read previous PRs that touched the same files; check whether their comments also apply here.
+- Agent #2 (bugs): scan the changed lines for real defects; ignore likely false positives.
+- Agent #3 (history): read git blame and history of the changed lines; flag bugs in this PR's changes that only make sense in light of that history.
+- Agent #4 (prior PRs): read previous PRs that touched the same files; check whether their review comments apply to this PR's changes.
 - Agent #5 (comments): read code comments in the modified files; flag anything in the diff that contradicts them.
 
 ## Step 4 — Validate, dedup, severity
 
-First **deduplicate**: merge findings that report the same issue at the same file and line — or on adjacent lines — into one (keep the clearest wording). Then **drop any finding already raised on this PR**: fetch a **bounded, recent page** of the PR's existing inline review comments (about the 100 most recent, newest first — do not page through the entire history) and read **only each comment's file path and title line**, not full bodies, so prior reviews never overload your context. Skip a finding whose file path and short title match one already posted, so a new push does not repost the same issue you already flagged on an earlier commit. Then drop **clear false positives** only (see the **False Positives to Ignore** section near the end). **Keep every remaining valid finding** and assign a severity — do not discard a finding for being minor; a real-but-minor issue is a **Low**, not a drop. The bar is validity, not a confidence cutoff.
+First **deduplicate**: merge findings that report the same issue at the same file and line — or on adjacent lines — into one (keep the clearest wording). Then **drop any finding already raised on this PR**: fetch a **bounded, recent page** of the PR's existing inline review comments (about the 100 most recent, newest first — do not page through the entire history) and read **only each comment's file path and title line**, not full bodies, so prior reviews never overload your context. Skip a finding whose file path and short title match one already posted, so a new push does not repost the same issue you already flagged on an earlier commit. Then drop **clear false positives** (see the **False Positives to Ignore** section near the end). Assign each remaining finding a severity. **Post every Critical, High, and Medium finding. Cap Low findings at the three most important per review and drop the rest** — Low is for genuinely minor issues, and a long tail of nitpicks reads as noise. When you are unsure whether something is a Low or not worth posting at all, drop it.
 
 - **Critical** — data loss, security/auth bypass, a crash, or clearly broken core behavior.
 - **High** — a real bug likely hit in normal use, or a clear violation of a project rule that matters in practice.
@@ -56,10 +56,10 @@ Repeat the eligibility check from Step 1, and re-fetch the head SHA. If it diffe
 
 ## Step 6 — Post one inline review
 
-**If there are no findings, do not post anything — skip the review entirely.** Never post a "no issues" / "looks good" review. Otherwise post **one** review: an inline comment per **on-diff** finding, plus any off-diff findings collected into a single summary comment. Use the posting tool for your runner (see **GitHub tools** above).
+**If there are no findings, do not post anything — skip the review entirely.** Never post a "no issues" / "looks good" review. Otherwise post **one** review: an inline comment per finding, plus a one-line summary body. Use the posting tool for your runner (see **GitHub tools** above).
 
-- Anchor each inline comment to the finding's `path`, line, and `side`, using the **full head SHA**. **Validate each anchor against the diff first** — a comment on a line not present in the diff is silently dropped or rejected, so move anything that will not anchor into the summary instead.
-- The summary body is one line (e.g. `Found 3 issues.`), optionally followed by an `Outside the diff:` list, one entry per off-diff finding (`path:line — Severity — explanation`). The count covers **every** finding, inline plus off-diff. Never include a "what was reviewed" / coverage summary or any description of your process.
+- Anchor each inline comment to the finding's `path`, line, and `side`, using the **full head SHA**. **Validate each anchor against the diff first.** Drop any finding whose line is not in the diff — it is out of scope — **except** when GitHub returned no patch for that changed file (it was too large to diff), where no line can be anchored: list those in the summary body instead.
+- The summary body is one line (e.g. `Found 3 issues.`) covering every posted finding, optionally followed by a list of findings on changed files too large to show a diff (`path:line — Severity — explanation`). Never include a "what was reviewed" / coverage summary or any description of your process.
 - End the summary body with **your runner's** hidden marker on its own line — `<!-- code-review:claude -->` if you are a Claude runner, `<!-- code-review:cursor -->` if you are a Cursor runner. A later run treats the head as already reviewed (Step 1c) when a non-dismissed review carrying **your** marker exists for the current head SHA, so the marker is what lets re-triggers skip re-reviewing the same commit.
 
 ## Inline comment format

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: code-review
-description: Review a GitHub pull request with parallel specialized agents and post inline review comments rated by severity. Surfaces every valid issue; does not fix anything. Use when asked to review a PR or run /code-review.
+description: Review a GitHub pull request with parallel specialized agents and post inline review comments rated by severity. Reviews the PR's changed lines and caps minor nitpicks; does not fix anything. Use when asked to review a PR or run /code-review.
 ---
 
 # Code Review
 
-Review a GitHub pull request with parallel specialized agents and post the findings as **inline review comments**, each rated by severity. Surface every valid issue — do not fix anything.
+Review a GitHub pull request with parallel specialized agents and post the findings as **inline review comments**, each rated by severity. Surface real issues, not nitpicks — do not fix anything.
 
-**Scope — pre-existing issues are in scope.** Do not limit the review to the lines this PR changed. Real bugs and project-rule violations that already existed in the touched files, or that the PR did not introduce, are within scope. Never dismiss a finding solely because it predates this PR.
+**Scope — review only what this PR changes.** Limit the review to the lines this PR adds or modifies. Every finding must anchor to a line in the diff; do not go hunting for pre-existing problems in untouched code. If a real issue sits on a line the PR did not touch — even in a file the PR edited — leave it out.
 
 ## GitHub tools — pick by runner
 
@@ -31,17 +31,17 @@ Then check eligibility (delegate to a sub-agent when sub-agents are available): 
 
 ## Step 3 — Review (parallel reviewers)
 
-Launch the following review agents in parallel (or sequentially in this thread if sub-agents are unavailable). Each reads the changed files and returns a flat list of findings — each with its **file path, line number, and diff side** (`RIGHT` for an added/current line, `LEFT` for a removed line using the base-side line number, or `off-diff` for a line the PR did not touch) plus the reason it was flagged:
+Launch the following review agents in parallel (or sequentially in this thread if sub-agents are unavailable). Each reads the changed files and returns a flat list of findings — each with its **file path, line number, and diff side** (`RIGHT` for an added/current line, or `LEFT` for a removed line using the base-side line number) plus the reason it was flagged:
 
 - Agent #1 (rules): audit the changes for compliance with the project rule files from Step 2. The rules are guidance for code generation, so not all apply during review.
-- Agent #2 (bugs): scan for real defects; ignore likely false positives. Pre-existing bugs in the touched files are in scope.
-- Agent #3 (history): read git blame and history of the changed files; flag bugs that only make sense in light of that history.
-- Agent #4 (prior PRs): read previous PRs that touched the same files; check whether their comments also apply here.
+- Agent #2 (bugs): scan the changed lines for real defects; ignore likely false positives.
+- Agent #3 (history): read git blame and history of the changed lines; flag bugs in this PR's changes that only make sense in light of that history.
+- Agent #4 (prior PRs): read previous PRs that touched the same files; check whether their review comments apply to this PR's changes.
 - Agent #5 (comments): read code comments in the modified files; flag anything in the diff that contradicts them.
 
 ## Step 4 — Validate, dedup, severity
 
-First **deduplicate**: merge findings that report the same issue at the same file and line — or on adjacent lines — into one (keep the clearest wording). Then **drop any finding already raised on this PR**: fetch a **bounded, recent page** of the PR's existing inline review comments (about the 100 most recent, newest first — do not page through the entire history) and read **only each comment's file path and title line**, not full bodies, so prior reviews never overload your context. Skip a finding whose file path and short title match one already posted, so a new push does not repost the same issue you already flagged on an earlier commit. Then drop **clear false positives** only (see the **False Positives to Ignore** section near the end). **Keep every remaining valid finding** and assign a severity — do not discard a finding for being minor; a real-but-minor issue is a **Low**, not a drop. The bar is validity, not a confidence cutoff.
+First **deduplicate**: merge findings that report the same issue at the same file and line — or on adjacent lines — into one (keep the clearest wording). Then **drop any finding already raised on this PR**: fetch a **bounded, recent page** of the PR's existing inline review comments (about the 100 most recent, newest first — do not page through the entire history) and read **only each comment's file path and title line**, not full bodies, so prior reviews never overload your context. Skip a finding whose file path and short title match one already posted, so a new push does not repost the same issue you already flagged on an earlier commit. Then drop **clear false positives** (see the **False Positives to Ignore** section near the end). Assign each remaining finding a severity. **Post every Critical, High, and Medium finding. Cap Low findings at the three most important per review and drop the rest** — Low is for genuinely minor issues, and a long tail of nitpicks reads as noise. When you are unsure whether something is a Low or not worth posting at all, drop it.
 
 - **Critical** — data loss, security/auth bypass, a crash, or clearly broken core behavior.
 - **High** — a real bug likely hit in normal use, or a clear violation of a project rule that matters in practice.
@@ -56,10 +56,10 @@ Repeat the eligibility check from Step 1, and re-fetch the head SHA. If it diffe
 
 ## Step 6 — Post one inline review
 
-**If there are no findings, do not post anything — skip the review entirely.** Never post a "no issues" / "looks good" review. Otherwise post **one** review: an inline comment per **on-diff** finding, plus any off-diff findings collected into a single summary comment. Use the posting tool for your runner (see **GitHub tools** above).
+**If there are no findings, do not post anything — skip the review entirely.** Never post a "no issues" / "looks good" review. Otherwise post **one** review: an inline comment per finding, plus a one-line summary body. Use the posting tool for your runner (see **GitHub tools** above).
 
-- Anchor each inline comment to the finding's `path`, line, and `side`, using the **full head SHA**. **Validate each anchor against the diff first** — a comment on a line not present in the diff is silently dropped or rejected, so move anything that will not anchor into the summary instead.
-- The summary body is one line (e.g. `Found 3 issues.`), optionally followed by an `Outside the diff:` list, one entry per off-diff finding (`path:line — Severity — explanation`). The count covers **every** finding, inline plus off-diff. Never include a "what was reviewed" / coverage summary or any description of your process.
+- Anchor each inline comment to the finding's `path`, line, and `side`, using the **full head SHA**. **Validate each anchor against the diff first.** Drop any finding whose line is not in the diff — it is out of scope — **except** when GitHub returned no patch for that changed file (it was too large to diff), where no line can be anchored: list those in the summary body instead.
+- The summary body is one line (e.g. `Found 3 issues.`) covering every posted finding, optionally followed by a list of findings on changed files too large to show a diff (`path:line — Severity — explanation`). Never include a "what was reviewed" / coverage summary or any description of your process.
 - End the summary body with **your runner's** hidden marker on its own line — `<!-- code-review:claude -->` if you are a Claude runner, `<!-- code-review:cursor -->` if you are a Cursor runner. A later run treats the head as already reviewed (Step 1c) when a non-dismissed review carrying **your** marker exists for the current head SHA, so the marker is what lets re-triggers skip re-reviewing the same commit.
 
 ## Inline comment format

--- a/.codex/skills/code-review/SKILL.md
+++ b/.codex/skills/code-review/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: "code-review"
-description: "Review a GitHub pull request with parallel specialized agents and post inline review comments rated by severity. Surfaces every valid issue; does not fix anything. Use when asked to review a PR or run /code-review."
+description: "Review a GitHub pull request with parallel specialized agents and post inline review comments rated by severity. Reviews the PR's changed lines and caps minor nitpicks; does not fix anything. Use when asked to review a PR or run /code-review."
 ---
 
 # Code Review
 
-Review a GitHub pull request with parallel specialized agents and post the findings as **inline review comments**, each rated by severity. Surface every valid issue — do not fix anything.
+Review a GitHub pull request with parallel specialized agents and post the findings as **inline review comments**, each rated by severity. Surface real issues, not nitpicks — do not fix anything.
 
-**Scope — pre-existing issues are in scope.** Do not limit the review to the lines this PR changed. Real bugs and project-rule violations that already existed in the touched files, or that the PR did not introduce, are within scope. Never dismiss a finding solely because it predates this PR.
+**Scope — review only what this PR changes.** Limit the review to the lines this PR adds or modifies. Every finding must anchor to a line in the diff; do not go hunting for pre-existing problems in untouched code. If a real issue sits on a line the PR did not touch — even in a file the PR edited — leave it out.
 
 ## GitHub tools — pick by runner
 
@@ -31,17 +31,17 @@ Then check eligibility (delegate to a sub-agent when sub-agents are available): 
 
 ## Step 3 — Review (parallel reviewers)
 
-Launch the following review agents in parallel (or sequentially in this thread if sub-agents are unavailable). Each reads the changed files and returns a flat list of findings — each with its **file path, line number, and diff side** (`RIGHT` for an added/current line, `LEFT` for a removed line using the base-side line number, or `off-diff` for a line the PR did not touch) plus the reason it was flagged:
+Launch the following review agents in parallel (or sequentially in this thread if sub-agents are unavailable). Each reads the changed files and returns a flat list of findings — each with its **file path, line number, and diff side** (`RIGHT` for an added/current line, or `LEFT` for a removed line using the base-side line number) plus the reason it was flagged:
 
 - Agent #1 (rules): audit the changes for compliance with the project rule files from Step 2. The rules are guidance for code generation, so not all apply during review.
-- Agent #2 (bugs): scan for real defects; ignore likely false positives. Pre-existing bugs in the touched files are in scope.
-- Agent #3 (history): read git blame and history of the changed files; flag bugs that only make sense in light of that history.
-- Agent #4 (prior PRs): read previous PRs that touched the same files; check whether their comments also apply here.
+- Agent #2 (bugs): scan the changed lines for real defects; ignore likely false positives.
+- Agent #3 (history): read git blame and history of the changed lines; flag bugs in this PR's changes that only make sense in light of that history.
+- Agent #4 (prior PRs): read previous PRs that touched the same files; check whether their review comments apply to this PR's changes.
 - Agent #5 (comments): read code comments in the modified files; flag anything in the diff that contradicts them.
 
 ## Step 4 — Validate, dedup, severity
 
-First **deduplicate**: merge findings that report the same issue at the same file and line — or on adjacent lines — into one (keep the clearest wording). Then **drop any finding already raised on this PR**: fetch a **bounded, recent page** of the PR's existing inline review comments (about the 100 most recent, newest first — do not page through the entire history) and read **only each comment's file path and title line**, not full bodies, so prior reviews never overload your context. Skip a finding whose file path and short title match one already posted, so a new push does not repost the same issue you already flagged on an earlier commit. Then drop **clear false positives** only (see the **False Positives to Ignore** section near the end). **Keep every remaining valid finding** and assign a severity — do not discard a finding for being minor; a real-but-minor issue is a **Low**, not a drop. The bar is validity, not a confidence cutoff.
+First **deduplicate**: merge findings that report the same issue at the same file and line — or on adjacent lines — into one (keep the clearest wording). Then **drop any finding already raised on this PR**: fetch a **bounded, recent page** of the PR's existing inline review comments (about the 100 most recent, newest first — do not page through the entire history) and read **only each comment's file path and title line**, not full bodies, so prior reviews never overload your context. Skip a finding whose file path and short title match one already posted, so a new push does not repost the same issue you already flagged on an earlier commit. Then drop **clear false positives** (see the **False Positives to Ignore** section near the end). Assign each remaining finding a severity. **Post every Critical, High, and Medium finding. Cap Low findings at the three most important per review and drop the rest** — Low is for genuinely minor issues, and a long tail of nitpicks reads as noise. When you are unsure whether something is a Low or not worth posting at all, drop it.
 
 - **Critical** — data loss, security/auth bypass, a crash, or clearly broken core behavior.
 - **High** — a real bug likely hit in normal use, or a clear violation of a project rule that matters in practice.
@@ -56,10 +56,10 @@ Repeat the eligibility check from Step 1, and re-fetch the head SHA. If it diffe
 
 ## Step 6 — Post one inline review
 
-**If there are no findings, do not post anything — skip the review entirely.** Never post a "no issues" / "looks good" review. Otherwise post **one** review: an inline comment per **on-diff** finding, plus any off-diff findings collected into a single summary comment. Use the posting tool for your runner (see **GitHub tools** above).
+**If there are no findings, do not post anything — skip the review entirely.** Never post a "no issues" / "looks good" review. Otherwise post **one** review: an inline comment per finding, plus a one-line summary body. Use the posting tool for your runner (see **GitHub tools** above).
 
-- Anchor each inline comment to the finding's `path`, line, and `side`, using the **full head SHA**. **Validate each anchor against the diff first** — a comment on a line not present in the diff is silently dropped or rejected, so move anything that will not anchor into the summary instead.
-- The summary body is one line (e.g. `Found 3 issues.`), optionally followed by an `Outside the diff:` list, one entry per off-diff finding (`path:line — Severity — explanation`). The count covers **every** finding, inline plus off-diff. Never include a "what was reviewed" / coverage summary or any description of your process.
+- Anchor each inline comment to the finding's `path`, line, and `side`, using the **full head SHA**. **Validate each anchor against the diff first.** Drop any finding whose line is not in the diff — it is out of scope — **except** when GitHub returned no patch for that changed file (it was too large to diff), where no line can be anchored: list those in the summary body instead.
+- The summary body is one line (e.g. `Found 3 issues.`) covering every posted finding, optionally followed by a list of findings on changed files too large to show a diff (`path:line — Severity — explanation`). Never include a "what was reviewed" / coverage summary or any description of your process.
 - End the summary body with **your runner's** hidden marker on its own line — `<!-- code-review:claude -->` if you are a Claude runner, `<!-- code-review:cursor -->` if you are a Cursor runner. A later run treats the head as already reviewed (Step 1c) when a non-dismissed review carrying **your** marker exists for the current head SHA, so the marker is what lets re-triggers skip re-reviewing the same commit.
 
 ## Inline comment format

--- a/.cursor/skills/code-review/SKILL.md
+++ b/.cursor/skills/code-review/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: code-review
-description: Review a GitHub pull request with parallel specialized agents and post inline review comments rated by severity. Surfaces every valid issue; does not fix anything. Use when asked to review a PR or run /code-review.
+description: Review a GitHub pull request with parallel specialized agents and post inline review comments rated by severity. Reviews the PR's changed lines and caps minor nitpicks; does not fix anything. Use when asked to review a PR or run /code-review.
 ---
 
 # Code Review
 
-Review a GitHub pull request with parallel specialized agents and post the findings as **inline review comments**, each rated by severity. Surface every valid issue — do not fix anything.
+Review a GitHub pull request with parallel specialized agents and post the findings as **inline review comments**, each rated by severity. Surface real issues, not nitpicks — do not fix anything.
 
-**Scope — pre-existing issues are in scope.** Do not limit the review to the lines this PR changed. Real bugs and project-rule violations that already existed in the touched files, or that the PR did not introduce, are within scope. Never dismiss a finding solely because it predates this PR.
+**Scope — review only what this PR changes.** Limit the review to the lines this PR adds or modifies. Every finding must anchor to a line in the diff; do not go hunting for pre-existing problems in untouched code. If a real issue sits on a line the PR did not touch — even in a file the PR edited — leave it out.
 
 ## GitHub tools — pick by runner
 
@@ -31,17 +31,17 @@ Then check eligibility (delegate to a sub-agent when sub-agents are available): 
 
 ## Step 3 — Review (parallel reviewers)
 
-Launch the following review agents in parallel (or sequentially in this thread if sub-agents are unavailable). Each reads the changed files and returns a flat list of findings — each with its **file path, line number, and diff side** (`RIGHT` for an added/current line, `LEFT` for a removed line using the base-side line number, or `off-diff` for a line the PR did not touch) plus the reason it was flagged:
+Launch the following review agents in parallel (or sequentially in this thread if sub-agents are unavailable). Each reads the changed files and returns a flat list of findings — each with its **file path, line number, and diff side** (`RIGHT` for an added/current line, or `LEFT` for a removed line using the base-side line number) plus the reason it was flagged:
 
 - Agent #1 (rules): audit the changes for compliance with the project rule files from Step 2. The rules are guidance for code generation, so not all apply during review.
-- Agent #2 (bugs): scan for real defects; ignore likely false positives. Pre-existing bugs in the touched files are in scope.
-- Agent #3 (history): read git blame and history of the changed files; flag bugs that only make sense in light of that history.
-- Agent #4 (prior PRs): read previous PRs that touched the same files; check whether their comments also apply here.
+- Agent #2 (bugs): scan the changed lines for real defects; ignore likely false positives.
+- Agent #3 (history): read git blame and history of the changed lines; flag bugs in this PR's changes that only make sense in light of that history.
+- Agent #4 (prior PRs): read previous PRs that touched the same files; check whether their review comments apply to this PR's changes.
 - Agent #5 (comments): read code comments in the modified files; flag anything in the diff that contradicts them.
 
 ## Step 4 — Validate, dedup, severity
 
-First **deduplicate**: merge findings that report the same issue at the same file and line — or on adjacent lines — into one (keep the clearest wording). Then **drop any finding already raised on this PR**: fetch a **bounded, recent page** of the PR's existing inline review comments (about the 100 most recent, newest first — do not page through the entire history) and read **only each comment's file path and title line**, not full bodies, so prior reviews never overload your context. Skip a finding whose file path and short title match one already posted, so a new push does not repost the same issue you already flagged on an earlier commit. Then drop **clear false positives** only (see the **False Positives to Ignore** section near the end). **Keep every remaining valid finding** and assign a severity — do not discard a finding for being minor; a real-but-minor issue is a **Low**, not a drop. The bar is validity, not a confidence cutoff.
+First **deduplicate**: merge findings that report the same issue at the same file and line — or on adjacent lines — into one (keep the clearest wording). Then **drop any finding already raised on this PR**: fetch a **bounded, recent page** of the PR's existing inline review comments (about the 100 most recent, newest first — do not page through the entire history) and read **only each comment's file path and title line**, not full bodies, so prior reviews never overload your context. Skip a finding whose file path and short title match one already posted, so a new push does not repost the same issue you already flagged on an earlier commit. Then drop **clear false positives** (see the **False Positives to Ignore** section near the end). Assign each remaining finding a severity. **Post every Critical, High, and Medium finding. Cap Low findings at the three most important per review and drop the rest** — Low is for genuinely minor issues, and a long tail of nitpicks reads as noise. When you are unsure whether something is a Low or not worth posting at all, drop it.
 
 - **Critical** — data loss, security/auth bypass, a crash, or clearly broken core behavior.
 - **High** — a real bug likely hit in normal use, or a clear violation of a project rule that matters in practice.
@@ -56,10 +56,10 @@ Repeat the eligibility check from Step 1, and re-fetch the head SHA. If it diffe
 
 ## Step 6 — Post one inline review
 
-**If there are no findings, do not post anything — skip the review entirely.** Never post a "no issues" / "looks good" review. Otherwise post **one** review: an inline comment per **on-diff** finding, plus any off-diff findings collected into a single summary comment. Use the posting tool for your runner (see **GitHub tools** above).
+**If there are no findings, do not post anything — skip the review entirely.** Never post a "no issues" / "looks good" review. Otherwise post **one** review: an inline comment per finding, plus a one-line summary body. Use the posting tool for your runner (see **GitHub tools** above).
 
-- Anchor each inline comment to the finding's `path`, line, and `side`, using the **full head SHA**. **Validate each anchor against the diff first** — a comment on a line not present in the diff is silently dropped or rejected, so move anything that will not anchor into the summary instead.
-- The summary body is one line (e.g. `Found 3 issues.`), optionally followed by an `Outside the diff:` list, one entry per off-diff finding (`path:line — Severity — explanation`). The count covers **every** finding, inline plus off-diff. Never include a "what was reviewed" / coverage summary or any description of your process.
+- Anchor each inline comment to the finding's `path`, line, and `side`, using the **full head SHA**. **Validate each anchor against the diff first.** Drop any finding whose line is not in the diff — it is out of scope — **except** when GitHub returned no patch for that changed file (it was too large to diff), where no line can be anchored: list those in the summary body instead.
+- The summary body is one line (e.g. `Found 3 issues.`) covering every posted finding, optionally followed by a list of findings on changed files too large to show a diff (`path:line — Severity — explanation`). Never include a "what was reviewed" / coverage summary or any description of your process.
 - End the summary body with **your runner's** hidden marker on its own line — `<!-- code-review:claude -->` if you are a Claude runner, `<!-- code-review:cursor -->` if you are a Cursor runner. A later run treats the head as already reviewed (Step 1c) when a non-dismissed review carrying **your** marker exists for the current head SHA, so the marker is what lets re-triggers skip re-reviewing the same commit.
 
 ## Inline comment format

--- a/.github/scripts/code_review.py
+++ b/.github/scripts/code_review.py
@@ -16,6 +16,7 @@ logger = logging.getLogger("code_review")
 HUNK_HEADER: Final[re.Pattern[str]] = re.compile(r"^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@")
 FENCE: Final[re.Pattern[str]] = re.compile(r"```(?:json)?\s*(\{.*\})\s*```", re.DOTALL)
 PRIOR_COMMENTS_LIMIT: Final[int] = 100
+LOW_FINDINGS_CAP: Final[int] = 3
 
 
 class ReviewConfig(TypedDict):
@@ -208,8 +209,10 @@ def parse_patch(patch: str) -> tuple[set[int], set[int]]:
     return right, left
 
 
-def diff_anchors(repo: str, pr_number: str, token: str) -> dict[str, tuple[set[int], set[int]]]:
-    """Map each changed file path to its valid (RIGHT, LEFT) inline-comment line numbers."""
+def diff_anchors(
+    repo: str, pr_number: str, token: str
+) -> tuple[dict[str, tuple[set[int], set[int]]], set[str]]:
+    """Map patched changed files to their (RIGHT, LEFT) anchor lines, plus changed files GitHub gave no patch for."""
 
     raw = run_gh(
         [
@@ -223,6 +226,7 @@ def diff_anchors(repo: str, pr_number: str, token: str) -> dict[str, tuple[set[i
     )
 
     anchors: dict[str, tuple[set[int], set[int]]] = {}
+    unpatched: set[str] = set()
 
     for line in raw.splitlines():
         if not line.strip():
@@ -232,8 +236,10 @@ def diff_anchors(repo: str, pr_number: str, token: str) -> dict[str, tuple[set[i
         patch = entry.get("patch")
         if patch:
             anchors[entry["filename"]] = parse_patch(patch)
+        else:
+            unpatched.add(entry["filename"])
 
-    return anchors
+    return anchors, unpatched
 
 
 def build_prompt(repo: str, pr_number: str, head_sha: str, diff: str) -> str:
@@ -249,7 +255,9 @@ def build_prompt(repo: str, pr_number: str, head_sha: str, diff: str) -> str:
         '{"findings": [{"path": "<repo-relative>", "line": <int>, "side": "RIGHT|LEFT", '
         '"severity": "Critical|High|Medium|Low", "title": "<short>", "body": "<1-3 sentences>"}]}\n'
         "Use RIGHT with new-file line numbers for added/current lines and LEFT with base-file line "
-        "numbers for removed lines. Surface every valid finding rated by severity; return an empty "
+        "numbers for removed lines. Only report findings on the diff's changed lines. Apply the "
+        "skill's severity bar: post every Critical, High, and Medium finding, but at most the three "
+        "most important Low findings. Order findings most-important-first. Return an empty "
         'list ({"findings": []}) when there are none.\n\n'
         f"Repository: {repo}\nPull request: #{pr_number}\nHead commit: {head_sha}\n\n"
         f"Unified diff:\n{diff}\n"
@@ -297,27 +305,56 @@ def parse_findings(reply: str) -> list[Finding]:
     return findings
 
 
+def cap_low_findings(findings: list[Finding]) -> list[Finding]:
+    """Keep every Critical/High/Medium finding but at most LOW_FINDINGS_CAP Low ones, in order."""
+
+    capped: list[Finding] = []
+    low_count = 0
+
+    for finding in findings:
+        if finding["severity"].strip().lower() == "low":
+            if low_count >= LOW_FINDINGS_CAP:
+                continue
+
+            low_count += 1
+
+        capped.append(finding)
+
+    return capped
+
+
 def comment_body(finding: Finding) -> str:
     """Render one inline comment body in the shared severity format."""
 
     return f"### {finding['title']}\n\n**{finding['severity']} Severity**\n\n{finding['body']}"
 
 
+def finding_anchors(finding: Finding, anchors: dict[str, tuple[set[int], set[int]]]) -> bool:
+    """Return True if the finding's line is present on its diff side."""
+
+    right, left = anchors.get(finding["path"], (set(), set()))
+
+    return finding["line"] in (left if finding["side"] == "LEFT" else right)
+
+
+def is_postable(
+    finding: Finding, anchors: dict[str, tuple[set[int], set[int]]], unpatched: set[str]
+) -> bool:
+    """Return True if the finding can be posted: inline-anchorable, or on a changed file with no patch."""
+
+    return finding_anchors(finding, anchors) or finding["path"] in unpatched
+
+
 def build_review(
-    head_sha: str,
-    findings: list[Finding],
-    anchors: dict[str, tuple[set[int], set[int]]],
+    head_sha: str, findings: list[Finding], anchors: dict[str, tuple[set[int], set[int]]]
 ) -> ReviewPayload:
-    """Build one BugBot-style review: an inline comment per on-diff finding plus an off-diff summary."""
+    """Build one review: inline comments for anchorable findings, a summary list for the rest."""
 
     comments: list[ReviewComment] = []
-    off_diff: list[str] = []
+    summary: list[str] = []
 
     for finding in findings:
-        right, left = anchors.get(finding["path"], (set(), set()))
-        valid = finding["line"] in (left if finding["side"] == "LEFT" else right)
-
-        if valid:
+        if finding_anchors(finding, anchors):
             comments.append(
                 {
                     "path": finding["path"],
@@ -327,14 +364,16 @@ def build_review(
                 }
             )
         else:
-            off_diff.append(
+            # Callers only pass postable findings, so a non-anchorable one is on a changed file
+            # that GitHub returned no patch for (too large) — surface it in the summary.
+            summary.append(
                 f"- {finding['path']}:{finding['line']} — {finding['severity']} — {finding['body']}"
             )
 
     count = len(findings)
     body = f"Found {count} issue{'s' if count != 1 else ''}."
-    if off_diff:
-        body = f"{body}\n\nOutside the diff:\n" + "\n".join(off_diff)
+    if summary:
+        body = f"{body}\n\nOn files too large to anchor inline:\n" + "\n".join(summary)
 
     body = f"{body}\n\n{CONFIG['cursor_marker']}"
 
@@ -431,7 +470,7 @@ async def run_cursor_review() -> int:
         return 0
 
     diff = run_gh(["pr", "diff", pr_number, "--repo", repo], token=token)
-    anchors = diff_anchors(repo, pr_number, token)
+    anchors, unpatched = diff_anchors(repo, pr_number, token)
     prompt = build_prompt(repo, pr_number, head_sha, diff)
 
     try:
@@ -472,8 +511,11 @@ async def run_cursor_review() -> int:
     posted = posted_finding_keys(repo, pr_number, token)
     findings = [finding for finding in findings if (finding["path"], finding["title"]) not in posted]
 
+    findings = [finding for finding in findings if is_postable(finding, anchors, unpatched)]
+    findings = cap_low_findings(findings)
+
     if not findings:
-        logger.info("Every finding was already posted on this PR; recording reviewed status.")
+        logger.info("No new in-scope findings to post; recording reviewed status.")
         mark_head_reviewed(repo, head_sha, token)
 
         return 0


### PR DESCRIPTION
Reduces code-review volume to focus on each PR's own changes and the highest-value findings — it was flagging far more than Bugbot because the rollout deliberately removed the confidence cutoff and kept pre-existing issues in scope.

**Skill (`code-review`)**
- **Scope → diff-only:** review only the lines the PR adds/modifies; stop hunting pre-existing issues in untouched code.
- **Severity → cap Low:** post every Critical/High/Medium finding, but cap Low at the **3 most important** per review and drop the rest.
- Re-scoped the bug / history / prior-PR lenses to the changed lines.

**Cursor runner (`code_review.py`)**
- Prompt updated to match (diff-only, Low cap, most-important-first).
- Added `cap_low_findings()` (cap = 3) as a deterministic backstop, applied **after** the posted-comment dedup so it only caps genuinely-new findings.

Synced across `.agents/` and the `.claude/` / `.cursor/` / `.codex/` mirrors.

https://claude.ai/code/session_01Qd5RpkdCL9ktzLrJgGugh5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qd5RpkdCL9ktzLrJgGugh5)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and CI review orchestration only; no application runtime or auth paths change.
> 
> **Overview**
> Narrows automated PR review so it matches **diff-only** scope and fewer nitpicks, after rollout volume exceeded Bugbot-style signal.
> 
> The **`code-review` skill** (same text in `.agents/` and `.claude` / `.cursor` / `.codex` mirrors) now limits findings to **lines the PR adds or modifies**, drops the **`off-diff`** path and “pre-existing issues in scope,” and tightens bug/history/prior-PR lenses to those changed lines. **Severity posting** keeps every Critical/High/Medium but **caps Low at three** per run and tells reviewers to drop marginal lows. **Step 6** drops findings that cannot anchor on the diff (except changed files with no GitHub patch), replacing the old “Outside the diff” summary with a list for **files too large to diff**.
> 
> **`.github/scripts/code_review.py`** aligns the Cursor CI runner: prompt enforces diff-only + Low cap + importance ordering; **`diff_anchors`** also tracks **unpatched** changed files; **`cap_low_findings`**, **`is_postable`**, and filtering after prior-comment dedup enforce scope and the Low cap before posting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 247910a2b379d7f7c4c911ca4620ec7e84913288. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->