### PR TITLE
Re-prompt the Cursor agent on an unparseable reply

### DIFF
--- a/.github/scripts/code_review.py
+++ b/.github/scripts/code_review.py
@@ -20,6 +20,7 @@ logger = logging.getLogger("code_review")
 HUNK_HEADER: Final[re.Pattern[str]] = re.compile(r"^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@")
 FENCE: Final[re.Pattern[str]] = re.compile(r"```(?:json)?\s*(\{.*\})\s*```", re.DOTALL)
 LOW_FINDINGS_CAP: Final[int] = 3
+MAX_PARSE_ATTEMPTS: Final[int] = 3
 
 
 class ReviewConfig(TypedDict):
@@ -548,6 +549,31 @@ def parse_findings(reply: str) -> list[Finding]:
     return findings
 
 
+async def collect_findings(agent: AsyncAgent, prompt: str) -> list[Finding]:
+    """Send the prompt and parse the reply, re-prompting the agent with the error on an unparseable reply."""
+
+    message = prompt
+    last_error = ""
+    for attempt in range(1, MAX_PARSE_ATTEMPTS + 1):
+        run = await agent.send(message)
+        reply = await run.text()
+
+        try:
+            return parse_findings(reply)
+        except (json.JSONDecodeError, AttributeError, KeyError, TypeError, ValueError) as exc:
+            last_error = str(exc)
+            logger.warning(
+                "Agent reply was not valid findings JSON (attempt %d/%d): %s", attempt, MAX_PARSE_ATTEMPTS, exc
+            )
+            message = (
+                f"Your previous reply could not be parsed as the findings JSON ({last_error}). "
+                "Reply with ONLY the JSON object described above — no prose, no code fence, no explanation. "
+                'Return {"findings": []} if there are no findings.'
+            )
+
+    raise ValueError(f"agent did not return valid findings JSON after {MAX_PARSE_ATTEMPTS} attempts: {last_error}")
+
+
 def cap_low_findings(findings: list[Finding]) -> list[Finding]:
     """Keep every Critical/High/Medium finding but at most LOW_FINDINGS_CAP Low ones, in order."""
 
@@ -823,8 +849,7 @@ async def run_cursor_review() -> int:
             )
 
             try:
-                run = await agent.send(prompt)
-                reply = await run.text()
+                findings = await collect_findings(agent, prompt)
             finally:
                 await agent.close()
         except CursorAgentError as exc:
@@ -835,9 +860,6 @@ async def run_cursor_review() -> int:
             concluded = True
 
             return 1
-
-        try:
-            findings = parse_findings(reply)
         except (json.JSONDecodeError, AttributeError, KeyError, TypeError, ValueError) as exc:
             logger.error("Could not parse agent reply: %s", exc)
             complete_check_run(


### PR DESCRIPTION
Fixes the transient Cursor review-bot failure `Could not parse agent reply: Expecting value: line 1 column 1` — the agent ran fine but its final reply was empty/non-JSON, so the check failed and only recovered on the next push.

## Change

`.github/scripts/code_review.py` now re-prompts the **same** agent session when its reply can't be parsed as findings JSON:

- New `collect_findings(agent, prompt)` helper sends the prompt, tries `parse_findings`, and on a parse error re-sends the error back to the agent asking for the required format — retrying up to `MAX_PARSE_ATTEMPTS` (3) before giving up.
- The agent is kept open across parse attempts (it was previously closed immediately after the first reply), so the agent keeps its conversation context and can correct the format on a retry.
- After all attempts fail, the run concludes as `Review failed` exactly as before — so the worst case is unchanged, but transient empty/non-JSON replies now self-recover within the run.

## Notes

- No dependency or behavior change beyond the retry; `MAX_PARSE_ATTEMPTS` is a module constant.
- Verified `cursor_sdk.AsyncAgent` retains session state across `send` (it exposes `list_messages`/`resume`), so re-sending continues the same conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Moearcqrk6AinJMXWkqE41

---
_Generated by [Claude Code](https://claude.ai/code/session_01Moearcqrk6AinJMXWkqE41)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to CI review-bot error handling; worst-case failure mode matches the prior single-attempt behavior.
> 
> **Overview**
> Addresses transient CI failures where the Cursor review agent returns empty or non-JSON replies (`Could not parse agent reply`), which previously failed the check until the next push.
> 
> Adds **`collect_findings`**, which keeps the same agent session open and retries up to **`MAX_PARSE_ATTEMPTS` (3)**. On a parse error it sends the error back and asks for findings JSON only (no prose or fences). **`run_cursor_review`** now uses this helper instead of a single send + parse. If all attempts fail, behavior is unchanged: the check still ends as **Review failed**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9620cb7c890bae4c4b9b38c486800956f058f1ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->