### PR TITLE
Document blind index per-row salt and make_blind_index in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,14 +352,16 @@ It takes the same normalization options, resolves the key from `BLIND_INDEX_SECR
 Pass a `salt` to fold a per-row identifier (e.g. an organization or user id) into the hash, so the same value indexes differently per row and can't be correlated by a reader without the key:
 
 ```python
-a = make_blind_index("123-45-6789", method=BlindIndexMethod.HMAC_SHA256, salt=org_a_id.bytes)
-b = make_blind_index("123-45-6789", method=BlindIndexMethod.HMAC_SHA256, salt=org_b_id.bytes)  # a != b
+a = make_blind_index("john@example.com", method=BlindIndexMethod.HMAC_SHA256, salt=org_a_id.bytes)
+b = make_blind_index("john@example.com", method=BlindIndexMethod.HMAC_SHA256, salt=org_b_id.bytes)  # a != b
 ```
 
-Lookups must use the same salt the row was written with; `salt=None` (default) is identical to an unsalted index. On SQLAlchemy columns, `make_blind_index_value` salts using the column's own flags:
+Lookups must use the same salt the row was written with; `salt=None` (default) is identical to an unsalted index. On a SQLAlchemy column, assigning a plain string stores an **unsalted** index, so salt both the write and the query with a precomputed value from `make_blind_index_value` (which uses the column's own flags):
 
 ```python
 bidx = User.__table__.c.blind_index_email.type
+
+user.blind_index_email = bidx.make_blind_index_value("john@example.com", salt=tenant_id.bytes)
 session.query(User).filter(
     User.blind_index_email == bidx.make_blind_index_value("john@example.com", salt=tenant_id.bytes)
 )

--- a/README.md
+++ b/README.md
@@ -335,6 +335,46 @@ Available options:
 | `BlindIndexMethod.HMAC_SHA256` | Fast HMAC-SHA256 keyed hash. Standard choice. |
 | `BlindIndexMethod.ARGON2` | Memory-hard Argon2 hash with deterministic salt. Better brute-force resistance. |
 
+### Computing Indexes Directly
+
+`SQLAlchemyBlindIndexValue` and the `BlindIndex` annotation hash automatically, but you can also compute a value yourself with `make_blind_index` — useful when building query filters or precomputing values for bulk writes:
+
+```python
+from pydantic_encryption import make_blind_index, BlindIndexMethod
+
+index = make_blind_index(
+    "john@example.com",
+    method=BlindIndexMethod.HMAC_SHA256,
+    normalize_to_lowercase=True,
+)
+```
+
+It accepts the same normalization options as the annotation, resolves the key from `BLIND_INDEX_SECRET_KEY` (override with `key=...`), and returns a `BlindIndexValue`. Passing an existing `BlindIndexValue` back in returns it unchanged, so a precomputed value flows through the SQLAlchemy column on both writes and equality comparisons.
+
+### Per-Row Salt
+
+By default the same plaintext produces the same index everywhere, which lets anyone with database read access (but not the key) correlate equal values across rows — for example, spotting the same SSN reused across tenants. Fold a **per-row salt** (a stable identifier such as an organization or user id) into the hash so identical values hash differently per row:
+
+```python
+index_a = make_blind_index("123-45-6789", method=BlindIndexMethod.HMAC_SHA256, salt=org_a_id.bytes)
+index_b = make_blind_index("123-45-6789", method=BlindIndexMethod.HMAC_SHA256, salt=org_b_id.bytes)
+# index_a != index_b — the same value can no longer be correlated across organizations
+```
+
+Within a single salt the index is still deterministic, so equality lookups work as long as you query with the same salt the row was written with. `salt=None` (the default) is byte-for-byte identical to an unsalted index, so existing data and unsalted columns are unaffected.
+
+For SQLAlchemy columns, `make_blind_index_value` salts using the column's own method and normalization flags:
+
+```python
+bidx = User.__table__.c.blind_index_email.type  # the SQLAlchemyBlindIndexValue
+
+# Store and later query a per-tenant salted index:
+user.blind_index_email = bidx.make_blind_index_value("john@example.com", salt=tenant_id.bytes)
+session.query(User).filter(
+    User.blind_index_email == bidx.make_blind_index_value("john@example.com", salt=tenant_id.bytes)
+)
+```
+
 ## Custom Encryption or Hashing
 
 Subclass `BaseModel` and override any of `encrypt_data`, `hash_data`, `blind_index_data` (or their async variants) to plug in your own logic. The post-init hook runs automatically:

--- a/README.md
+++ b/README.md
@@ -337,39 +337,29 @@ Available options:
 
 ### Computing Indexes Directly
 
-`SQLAlchemyBlindIndexValue` and the `BlindIndex` annotation hash automatically, but you can also compute a value yourself with `make_blind_index` — useful when building query filters or precomputing values for bulk writes:
+`make_blind_index` computes a `BlindIndexValue` outside the annotation/column path — handy for query filters or bulk-write precomputation:
 
 ```python
 from pydantic_encryption import make_blind_index, BlindIndexMethod
 
-index = make_blind_index(
-    "john@example.com",
-    method=BlindIndexMethod.HMAC_SHA256,
-    normalize_to_lowercase=True,
-)
+index = make_blind_index("john@example.com", method=BlindIndexMethod.HMAC_SHA256, normalize_to_lowercase=True)
 ```
 
-It accepts the same normalization options as the annotation, resolves the key from `BLIND_INDEX_SECRET_KEY` (override with `key=...`), and returns a `BlindIndexValue`. Passing an existing `BlindIndexValue` back in returns it unchanged, so a precomputed value flows through the SQLAlchemy column on both writes and equality comparisons.
+It takes the same normalization options, resolves the key from `BLIND_INDEX_SECRET_KEY` (override with `key=...`), and passes an existing `BlindIndexValue` through unchanged.
 
 ### Per-Row Salt
 
-By default the same plaintext produces the same index everywhere, which lets anyone with database read access (but not the key) correlate equal values across rows — for example, spotting the same SSN reused across tenants. Fold a **per-row salt** (a stable identifier such as an organization or user id) into the hash so identical values hash differently per row:
+Pass a `salt` to fold a per-row identifier (e.g. an organization or user id) into the hash, so the same value indexes differently per row and can't be correlated by a reader without the key:
 
 ```python
-index_a = make_blind_index("123-45-6789", method=BlindIndexMethod.HMAC_SHA256, salt=org_a_id.bytes)
-index_b = make_blind_index("123-45-6789", method=BlindIndexMethod.HMAC_SHA256, salt=org_b_id.bytes)
-# index_a != index_b — the same value can no longer be correlated across organizations
+a = make_blind_index("123-45-6789", method=BlindIndexMethod.HMAC_SHA256, salt=org_a_id.bytes)
+b = make_blind_index("123-45-6789", method=BlindIndexMethod.HMAC_SHA256, salt=org_b_id.bytes)  # a != b
 ```
 
-Within a single salt the index is still deterministic, so equality lookups work as long as you query with the same salt the row was written with. `salt=None` (the default) is byte-for-byte identical to an unsalted index, so existing data and unsalted columns are unaffected.
-
-For SQLAlchemy columns, `make_blind_index_value` salts using the column's own method and normalization flags:
+Lookups must use the same salt the row was written with; `salt=None` (default) is identical to an unsalted index. On SQLAlchemy columns, `make_blind_index_value` salts using the column's own flags:
 
 ```python
-bidx = User.__table__.c.blind_index_email.type  # the SQLAlchemyBlindIndexValue
-
-# Store and later query a per-tenant salted index:
-user.blind_index_email = bidx.make_blind_index_value("john@example.com", salt=tenant_id.bytes)
+bidx = User.__table__.c.blind_index_email.type
 session.query(User).filter(
     User.blind_index_email == bidx.make_blind_index_value("john@example.com", salt=tenant_id.bytes)
 )

--- a/tests/unit/test_make_blind_index.py
+++ b/tests/unit/test_make_blind_index.py
@@ -43,9 +43,9 @@ class TestMakeBlindIndexHMAC:
     def test_salted_differs_from_unsalted(self):
         """Test that providing a salt changes the output."""
 
-        unsalted = make_blind_index("123456789", method=BlindIndexMethod.HMAC_SHA256, key=TEST_KEY)
+        unsalted = make_blind_index("5550100", method=BlindIndexMethod.HMAC_SHA256, key=TEST_KEY)
         salted = make_blind_index(
-            "123456789", method=BlindIndexMethod.HMAC_SHA256, salt=ORG_SALT, key=TEST_KEY
+            "5550100", method=BlindIndexMethod.HMAC_SHA256, salt=ORG_SALT, key=TEST_KEY
         )
 
         assert salted != unsalted
@@ -53,17 +53,17 @@ class TestMakeBlindIndexHMAC:
     def test_same_value_and_salt_reproduce(self):
         """Test that the same (value, salt) pair is deterministic."""
 
-        first = make_blind_index("123456789", method=BlindIndexMethod.HMAC_SHA256, salt=ORG_SALT, key=TEST_KEY)
-        second = make_blind_index("123456789", method=BlindIndexMethod.HMAC_SHA256, salt=ORG_SALT, key=TEST_KEY)
+        first = make_blind_index("5550100", method=BlindIndexMethod.HMAC_SHA256, salt=ORG_SALT, key=TEST_KEY)
+        second = make_blind_index("5550100", method=BlindIndexMethod.HMAC_SHA256, salt=ORG_SALT, key=TEST_KEY)
 
         assert first == second
 
     def test_different_salts_differ(self):
         """Test that the same value under different salts yields different indices."""
 
-        first = make_blind_index("123456789", method=BlindIndexMethod.HMAC_SHA256, salt=ORG_SALT, key=TEST_KEY)
+        first = make_blind_index("5550100", method=BlindIndexMethod.HMAC_SHA256, salt=ORG_SALT, key=TEST_KEY)
         second = make_blind_index(
-            "123456789", method=BlindIndexMethod.HMAC_SHA256, salt=OTHER_SALT, key=TEST_KEY
+            "5550100", method=BlindIndexMethod.HMAC_SHA256, salt=OTHER_SALT, key=TEST_KEY
         )
 
         assert first != second
@@ -72,14 +72,14 @@ class TestMakeBlindIndexHMAC:
         """Test that normalization runs before the salt is folded in."""
 
         formatted = make_blind_index(
-            "123-45-6789",
+            "555-0100",
             method=BlindIndexMethod.HMAC_SHA256,
             salt=ORG_SALT,
             strip_non_digits=True,
             key=TEST_KEY,
         )
         digits = make_blind_index(
-            "123456789",
+            "5550100",
             method=BlindIndexMethod.HMAC_SHA256,
             salt=ORG_SALT,
             strip_non_digits=True,
@@ -91,10 +91,10 @@ class TestMakeBlindIndexHMAC:
     def test_salt_uses_length_prefixed_encoding(self):
         """Test that the salted HMAC folds in a length-tagged salt before the normalized value."""
 
-        message = len(ORG_SALT).to_bytes(4, "big") + ORG_SALT + b"123456789"
+        message = len(ORG_SALT).to_bytes(4, "big") + ORG_SALT + b"5550100"
         expected = hmac.new(TEST_KEY.encode("utf-8"), message, hashlib.sha256).digest()
         result = make_blind_index(
-            "123-45-6789",
+            "555-0100",
             method=BlindIndexMethod.HMAC_SHA256,
             salt=ORG_SALT,
             strip_non_digits=True,
@@ -133,7 +133,7 @@ class TestMakeBlindIndexHMAC:
         """Test that an already-computed BlindIndexValue is returned unchanged."""
 
         precomputed = make_blind_index(
-            "123456789", method=BlindIndexMethod.HMAC_SHA256, salt=ORG_SALT, key=TEST_KEY
+            "5550100", method=BlindIndexMethod.HMAC_SHA256, salt=ORG_SALT, key=TEST_KEY
         )
         again = make_blind_index(
             precomputed, method=BlindIndexMethod.HMAC_SHA256, salt=OTHER_SALT, key=TEST_KEY

--- a/tests/unit/test_sqlalchemy/test_blind_index.py
+++ b/tests/unit/test_sqlalchemy/test_blind_index.py
@@ -179,8 +179,8 @@ class TestSQLAlchemyBlindIndexValueMakeBlindIndexValue:
 
     def test_uses_column_normalization_flags(self):
         salt = b"\x01" * 16
-        formatted = self.digit_adapter.make_blind_index_value("123-45-6789", salt=salt)
-        digits = self.digit_adapter.make_blind_index_value("123456789", salt=salt)
+        formatted = self.digit_adapter.make_blind_index_value("555-0100", salt=salt)
+        digits = self.digit_adapter.make_blind_index_value("5550100", salt=salt)
         assert formatted == digits
 
     def test_salted_value_passes_through_bind(self):


### PR DESCRIPTION
## Summary

Documentation only. The README's **Blind Indexes** section predated the per-row salt feature and the public `make_blind_index` factory, so it's brought up to date with the current (`0.12.0`) API.

## Changes

- **Computing Indexes Directly**: documents `make_blind_index(...)` for computing a `BlindIndexValue` outside the annotation/column path (query filters, bulk-write precomputation), including key resolution and the pass-through of precomputed values.
- **Per-Row Salt**: explains the `salt` argument on `make_blind_index` and `SQLAlchemyBlindIndexValue.make_blind_index_value`, why it matters (defeats cross-row correlation by a keyless reader), that lookups must use the same salt, and that `salt=None` is byte-for-byte identical to an unsalted index.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShQ7HLUtvyFG1qzwnieAfA

---
_Generated by [Claude Code](https://claude.ai/code/session_01ShQ7HLUtvyFG1qzwnieAfA)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test fixture wording only; no library or runtime behavior changes.
> 
> **Overview**
> The **Blind Indexes** README is extended with two sections that match the current API: **`make_blind_index`** for computing `BlindIndexValue` outside model/column annotations (filters, bulk writes, key override, pass-through of precomputed values), and **per-row `salt`** (why it blocks cross-row correlation, lookup/write parity, and using `SQLAlchemyBlindIndexValue.make_blind_index_value` when plain string assignment stays unsalted).
> 
> Unit tests only swap salted/normalization examples from SSN-shaped strings (`123-45-6789` / `123456789`) to fictional phone digits (`555-0100` / `5550100`); assertions and behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7c7b7800a615e120f4557087a8c73238be11fec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->