### PR TITLE
chore: sync agent files

### DIFF
--- a/.agents/skills/code-review-loop/SKILL.md
+++ b/.agents/skills/code-review-loop/SKILL.md
@@ -1,15 +1,26 @@
 ---
 name: code-review-loop
-description: Run code-review repeatedly on its complete selected review target, investigate and fix every legitimate functional finding, validate and push the fixes, and stop only after two consecutive rounds with no functional findings (or a third when the second also makes simplifications). Any functional finding resets that stabilization sequence. Use when asked to review-and-fix, keep reviewing until clean, or run a code review loop.
+description: Run code-simplify once across the whole selected pull-request target, then run code-review repeatedly, investigate and fix every legitimate functional finding, validate and push the fixes, and stop only after two consecutive rounds with no functional findings (or a third when the second also makes simplifications). Any functional finding resets that stabilization sequence. Use when asked to review-and-fix, keep reviewing until clean, or run a code review loop.
 ---
 
 # Code Review Loop
 
 ## Dependencies
 
+- `code-simplify` — performs the whole-target simplification pass before review rounds begin.
 - `code-review` — performs each complete review pass in the loop.
 
 Drive the branch or session-derived review target to a clean functional result. Use `code-review` for every review pass so target selection, branch/PR creation when needed, review lenses, severity, and chat-only reporting stay consistent.
+
+## Pre-loop simplification
+
+Before initializing `noFunctionalFindingRounds`, running baseline validation, or starting the first review round:
+
+1. Establish the complete selected target with `code-review`'s target-selection and branch/draft-PR rules, but do not perform a review pass yet.
+2. Run `code-simplify` once across the whole selected target: the complete base-to-head pull-request or branch diff plus intended untracked files, never only the latest commit or most recent fixes. Apply every legitimate behavior-preserving simplification it finds.
+3. Stage only the intended simplification changes, discard generated or build outputs, commit, push, and refresh the complete target before the review loop starts. If the selected target was session commits on the default branch and simplification changes are needed, first create a new branch from that head and open a draft pull request for the changes.
+
+This simplification pass is mandatory, happens only once before the loop, does not count as a review pass, and does not change `noFunctionalFindingRounds`.
 
 ## No-functional-finding stabilization rounds
 

--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -46,6 +46,8 @@ Use the platform's pull-request tools when available, with `gh` as a fallback. G
 
 Launch these reviewers in parallel when subagents are available, or run them sequentially otherwise. Each reviewer must inspect only lines changed by the selected target and return a flat list with path, line, diff side (`RIGHT` for added/current or `LEFT` for removed/base), severity candidate, concrete trigger, and reasoning.
 
+If the user provides a new task while reviewers are running, interrupt every reviewer immediately and discard their results before starting that task. Restart the review only after the task is complete on its new baseline.
+
 1. **Rules** — check applicable repository rules against surrounding conventions.
 2. **Bugs** — find high-confidence correctness, data-loss, security, performance, or UX defects.
 3. **History** — use blame and history to identify regressions against prior intent.

--- a/.agents/skills/coordinate-repositories/SKILL.md
+++ b/.agents/skills/coordinate-repositories/SKILL.md
@@ -13,13 +13,10 @@ Carry out the caller's task consistently across the selected repository collecti
 2. For each candidate, read the relevant files and enough local guidance to understand whether the task applies. Keep repository-specific behavior unless the caller explicitly requests a unification.
 3. Choose the task mode:
    - For a read-only task, gather evidence from every applicable repository and merge it into one clearly attributed result.
-   - For a change or review-and-fix task, before selecting a worktree or branch, query the hosting service for an open pull request whose current head branch and task scope match the candidate. Verify its current state, exact remote head branch, and task scope. Never treat a local branch, remote-tracking branch, remembered URL, or prior task output as evidence that a pull request should receive new work.
-4. For a change or review-and-fix task:
-   - When a verified matching pull request is open, create an isolated worktree from that pull request's remote head branch and update only that pull request.
-   - When no verified matching pull request is open—or it is merged, closed, missing, or its branch was deleted—create a fresh isolated worktree from the current remote default branch and a new collision-free branch. When the user authorizes persistent changes, validate first, then commit, push, and open a new focused pull request.
-   - In every case, leave the original checkout, branch, and unrelated dirty or in-progress work untouched.
-5. Carry only the user-authorized task artifacts into each isolated worktree. Do not copy unrelated in-progress changes, generated outputs, credentials, or machine-specific configuration.
-6. Validate each completed repository with the relevant native checks. If the task manages generated files, use its owning generator rather than hand-editing generated outputs.
+   - For a change or review-and-fix task, work only in an isolated worktree based on that repository's remote default branch. Leave the original checkout, branch, and unrelated dirty work untouched.
+4. Carry only the user-authorized task artifacts into each isolated worktree. Do not copy unrelated in-progress changes, generated outputs, credentials, or machine-specific configuration.
+5. Validate each completed repository with the relevant native checks. If the task manages generated files, use its owning generator rather than hand-editing generated outputs.
+6. Before selecting a worktree or reusing a pull request, query the hosting service for the pull request associated with the candidate branch and verify its current state, branch, and task scope. Never infer that a pull request is active from a local branch, remote-tracking branch, remembered URL, or prior task output. Treat a merged, closed, missing, or branch-deleted pull request as absent: create a fresh isolated worktree and a new branch from the current remote default branch, then open a new focused pull request. Never append work to the old branch or push it merely because it remains locally available. Reuse only a verified open pull request for the same active branch and task scope.
 7. Report every repository completed, skipped, or blocked; the applied or gathered result; validation; and all pull-request links created or updated.
 
 ## Guardrails

--- a/.agents/skills/propagate-skill/SKILL.md
+++ b/.agents/skills/propagate-skill/SKILL.md
@@ -5,7 +5,7 @@ description: Propagate explicitly requested skills, rules, and their changes acr
 
 # Propagate Skill Changes
 
-Replicate the requested semantic change, not the originating skill file wholesale.
+Replicate the requested semantic change and newer generic guidance, not the originating skill file wholesale.
 
 ## Dependencies
 
@@ -19,6 +19,7 @@ Replicate the requested semantic change, not the originating skill file wholesal
 4. Establish the in-scope target repositories from the bounded collection and the user's request. Exclude repositories whose primary purpose is developing, packaging, testing, or operating the agent-synchronization system itself: treat them as system repositories, not consumers, even when they contain `.agents` artifacts. Do not create, update, or include propagated skills or rules in those repositories unless the user specifically requests a change to that system repository. Assess every selected skill or rule, including recursively selected dependencies, independently for applicability to every remaining candidate target, using that repository's languages, frameworks, tooling, workflow, and existing agent configuration; do not use predefined skill-to-repository mappings. For every selected skill, update its existing `.agents/skills/<name>/SKILL.md` or create the missing skill directory and source file only in targets where the assessment is positive. For every selected rule, update its existing `.agents/rules/<name>.md` or create it only where the assessment is positive. Apply propagation only inside the selected `.agents/skills/<name>/` or `.agents/rules/<name>.md` paths; never create or edit provider mirrors such as `.codex`, `.claude`, or `.cursor`.
 5. Before comparing, read the complete originating file and the complete existing target file (when present), plus enough nearby target guidance to understand its repository-specific context. Never infer that files are identical from matching names, prior propagation, hashes, or a partial diff. Compare full text, line counts, and an exact diff before deciding whether a target is current. Then classify every difference before changing it:
    - **Requested semantic delta** — behavior the user explicitly requested in this propagation. Treat a direct change to the originating skill or rule as generic and propagate it to every applicable consumer unless the user, the source wording, or target evidence makes it repository-specific. Rewrite only that delta where it fits.
+   - **Stale generic guidance** — target wording known to be an older revision of the same repository-neutral guidance now present in the origin, based on repository history, a prior propagation, or another unambiguous superseding contract. Replace it with the newer originating wording. Never preserve or report stale generic wording as candidate conflicting or target-specific guidance merely because it differs from the current requested delta.
    - **Candidate conflicting guidance** — extra or different behavior found in a consumer that is not part of the current requested delta. First determine whether it is repository-specific. If it is generic conflicting guidance, preserve it where it is, report the exact difference and applicability evidence, and ask whether its wording should be merged into every applicable consumer and the originating repository. Do not make that choice merely because the files differ.
    - **Target-specific guidance** — behavior justified by the target's own tools, product, or workflow. Preserve it and report the variance.
 
@@ -37,5 +38,6 @@ Replicate the requested semantic change, not the originating skill file wholesal
 - Author and replicate canonical `.agents` artifacts; provider-specific outputs must be generated only by the repository synchronization system when it is in scope.
 - Treat locally generated provider outputs as disposable test artifacts and leave their publication to CI.
 - Keep replicated code examples and reusable instructions repository-neutral; retain domain-specific material only where it is relevant to that target.
+- Replace known older generic guidance with its newer canonical wording; preservation applies only to current repository-specific guidance or unresolved generic conflicts whose lineage is unknown.
 - Do not turn textual similarity or difference into authority: propagate every applicable generic requested delta, preserve repository-specific guidance, and ask the user to choose before elevating an unrequested consumer-only conflict into a cross-repository merge.
 - Never propagate secrets, absolute machine paths, generated mirrors, or repository-specific operational details to unrelated repositories.


### PR DESCRIPTION
## Summary

- run code-simplify across the complete PR target before code-review-loop stabilization
- upgrade stale generic review-skill wording to the current canonical contracts
- make propagate-skill replace known older generic wording during future rollouts

## Validation

- skill quick validation
- exact canonical equivalence
- git diff --check